### PR TITLE
drop TRUE tm_g_distribution

### DIFF
--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -515,17 +515,17 @@ srv_distribution <- function(input,
         )
         mt_args <- list(
           test = quote(stats::t.test),
-          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]]))),
+          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]], drop = TRUE))),
           groups = c(g_var)
         )
         mv_args <- list(
           test = quote(stats::var.test),
-          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]]))),
+          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]], drop = TRUE))),
           groups = c(g_var)
         )
         mks_args <- list(
           test = quote(stats::ks.test),
-          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]]))),
+          args = bquote(unname(split(.[[.(dist_var)]], .[[.(s_var)]], drop = TRUE))),
           groups = c(g_var)
         )
 


### PR DESCRIPTION
closes #91 

some of tests which using split function needed an additional arg `drop = TRUE` inside split function. This is needed when we filter out some variable levels.

![image](https://user-images.githubusercontent.com/10676545/129720721-5bf5a412-d769-4e6c-a57f-fb5cbfe8764b.png)
