### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -33,5 +33,5 @@
 ^templates$
 ^test_full_example$
 ^TODO\.md$
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$
 ^LICENSE\.md$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\.yaml$.

Dot was not escaped