### PR TITLE
allow file viewer app to run despite bad file path

### DIFF
--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -60,7 +60,7 @@ tm_file_viewer <- function(label = "File Viewer Module",
     if (!all(idx)) {
       warning(
         paste0(
-          "Non-existant file or url path. Please provide valid paths for:\n",
+          "Non-existent file or url path. Please provide valid paths for:\n",
           paste0(input_path[!idx], collapse = "\n")
         )
       )


### PR DESCRIPTION
closes insightsengineering/coredev-tasks#354 and insightsengineering/coredev-tasks#353

to test:

```r
data <- data.frame(1)

app <- init(
  data = teal_data(
    dataset("data", data)
  ),
  modules = root_modules(
    # tm_file_viewer(input_path = list(fake_url = "fake", ".")) should run
    # tm_file_viewer(input_path = "") should run
    # tm_file_viewer(input_path = list()) should run
    tm_file_viewer(input_path = list(url = "https://raw.githubusercontent.com/kpagacz/spoj/main/polish/AL_04_03/solutionasdfasdf.cpp")) # should run
  )
)
shinyApp(app$ui, app$server)
```