### PR TITLE
handled edge case param inputs in file viewer

### DIFF
--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -42,6 +42,10 @@ tm_file_viewer <- function(label = "File Viewer Module",
     ifelse(is.null(check), TRUE, FALSE)
   }
 
+  if (is.null(label) || length(label) == 0 || label == "") {
+    label <- " "
+  }
+
   stop_if_not(
     is_character_single(label),
     is_character_list(input_path) || is_character_vector(input_path),


### PR DESCRIPTION
closes #207 

to test:

```r
data <- data.frame(1)

app <- init(
  data = teal_data(
    dataset("data", data)
  ),
  modules = root_modules(
    tm_file_viewer(
      label = "", # change to NULL, character(0), etc.
      input_path = list("."))
  )
)
## Not run: 
shinyApp(app$ui, app$server)
```