### PR TITLE
devops: removed test.nest dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Suggests:
     rmarkdown,
     scda.2021(>= 0.1.1),
     scda(>= 0.1.1),
-    test.nest (>= 0.2.11),
     testthat (>= 2.0)
 VignetteBuilder:
     knitr

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -23,7 +23,4 @@ upstream_repos:
   insightsengineering/utils.nest:
     repo: insightsengineering/utils.nest
     host: https://github.com
-  insightsengineering/test.nest:
-    repo: insightsengineering/test.nest
-    host: https://github.com
 downstream_repos:

--- a/tests/testthat/test_nest.R
+++ b/tests/testthat/test_nest.R
@@ -1,3 +1,0 @@
-library(test.nest)
-
-test_all()


### PR DESCRIPTION
Related to insightsengineering/coredev-tasks#70
