### PR TITLE
inner_join instead of left_join in outliers 

### DIFF
--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -227,7 +227,7 @@ srv_outliers <- function(input, output, session, datasets, outlier_var,
   merged_data <- data_merge_srv(
     selector_list = reactive_select_input,
     datasets = datasets,
-    merge_function = "dplyr::left_join"
+    merge_function = "dplyr::inner_join"
   )
 
   is_cat_filter_spec <- inherits(categorical_var[[1]]$filter[[1]], "filter_spec")


### PR DESCRIPTION
closes #248 

Don't remember the reason why `left_join` was used over `inner_join`. But I have experimented with it, and the only difference that I see is the bug that is caused by using `left_join`.

Please test with app in ticket.