### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -187,7 +187,7 @@ ui_a_regression <- function(id, ...) {
           class = "teal-tooltip",
           tagList(
             "Outlier definition:",
-            icon("info-circle"),
+            icon("circle-info"),
             span(
               class = "tooltiptext",
               paste(

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -253,7 +253,7 @@ ui_distribution <- function(id, ...) {
             class = "teal-tooltip",
             tagList(
               "Distribution:",
-              icon("info-circle"),
+              icon("circle-info"),
               span(
                 class = "tooltiptext",
                 "Default parameters are optimized with MASS::fitdistr function."

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -256,7 +256,7 @@ encoding_missing_data <- function(id, summary_per_patient = FALSE, ggtheme, data
           class = "teal-tooltip",
           tagList(
             "Add **anyna** variable",
-            icon("info-circle"),
+            icon("circle-info"),
             span(
               class = "tooltiptext",
               "Describes the number of observations with at least one missing value in any variable."
@@ -272,7 +272,7 @@ encoding_missing_data <- function(id, summary_per_patient = FALSE, ggtheme, data
             class = "teal-tooltip",
             tagList(
               "Add summary per patients",
-              icon("info-circle"),
+              icon("circle-info"),
               span(
                 class = "tooltiptext",
                 paste(

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -335,7 +335,7 @@ srv_variable_browser <- function(id, datasets, reporter, datasets_selected, ggpl
           class = "teal-tooltip",
           tagList(
             "Outlier definition:",
-            icon("info-circle"),
+            icon("circle-info"),
             span(
               class = "tooltiptext",
               paste(

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,8 +239,8 @@ variable_type_icons <- function(var_type) {
   checkmate::assert_character(var_type, any.missing = FALSE)
 
   class_to_icon <- list(
-    numeric = "sort-numeric-up",
-    integer = "sort-numeric-up",
+    numeric = "arrow-up-1-9",
+    integer = "arrow-up-1-9",
     logical = "pause",
     Date = "calendar",
     POSIXct = "calendar",
@@ -248,7 +248,7 @@ variable_type_icons <- function(var_type) {
     factor = "chart-bar",
     character = "keyboard",
     primary_key = "key",
-    unknown = "question-circle"
+    unknown = "circle-question"
   )
   class_to_icon <- lapply(class_to_icon, function(icon_name) toString(icon(icon_name, lib = "font-awesome")))
 


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```