### PR TITLE
server_rendering argument to `tm_data_table`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * Added the `teal.reporter` functionality to all modules.
 * Added log transformation options to `tm_g_scatterplot`.
+* Added `server_rendering` flag to `tm_data_table` to control whether the table is rendered server or client side.
 
 ### Bug fixes
 * Fixed an overflow for very wide `tm_a_pca` tables.

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -11,6 +11,7 @@ tm_data_table(
   dt_args = list(),
   dt_options = list(searching = FALSE, pageLength = 30, lengthMenu = c(5, 15, 30, 100),
     scrollX = TRUE),
+  server_rendering = FALSE,
   pre_output = NULL,
   post_output = NULL
 )
@@ -32,6 +33,9 @@ If vector of length zero (default) then all datasets are shown.}
 
 \item{dt_options}{(named \code{list}) The \code{options} argument to \code{DT::datatable}. By default
 \code{list(searching = FALSE, pageLength = 30, lengthMenu = c(5, 15, 30, 100), scrollX = TRUE)}}
+
+\item{server_rendering}{(\code{logical}) should the data table be rendered server side
+(see \code{server} argument of \code{DT::renderDataTable()})}
 
 \item{pre_output}{(\code{shiny.tag}, optional)\cr
 with text placed before the output to put the output into context. For example a title.}


### PR DESCRIPTION
Closes #442 fyi @npaszty 

Test with e.g.

```
library(teal.modules.general)
library(scda)

server_rendering <- TRUE # or set to FALSE

ADSL <- synthetic_cdisc_data("latest")$adsl
ADTTE <- synthetic_cdisc_data("latest")$adtte

app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL, code = "ADSL <- synthetic_cdisc_data(\"latest\")$adsl"),
    cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- synthetic_cdisc_data(\"latest\")$adtte"),
    check = TRUE
  ),
  modules = modules(
    tm_data_table(
      dt_args = list(extensions = c("Buttons", "ColReorder", "FixedHeader")),
      dt_options = list(
        searching = FALSE,
        pageLength = 30,
        lengthMenu = c(5, 15, 25, 50, 100),
        scrollX = FALSE,
        dom = "lBrtip",
        buttons = c("copy", "csv", "excel", "pdf", "print"),
        colReorder = TRUE,
        fixedHeader = TRUE
      ),
      server_rendering = server_rendering
    )
  )
)

shinyApp(app$ui, app$server)

```
