### PR TITLE
allow easy close for front page module

### DIFF
--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -184,7 +184,8 @@ srv_front_page <- function(id, datasets, tables, show_metadata) {
           modalDialog(
             title = "Metadata",
             dataTableOutput(ns("metadata_table")),
-            size = "l"
+            size = "l",
+            easyClose = TRUE
           )
         )
       )


### PR DESCRIPTION
Closes https://github.com/insightsengineering/coredev-tasks/issues/376

Test with 

```
library(scda)
library(teal.modules.general)

table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))
table_3 <- data.frame(Info = c("E", "F"), Text = c("G", "H"))

table_input <- list(
  "Table 1" = table_1,
  "Table 2" = table_2,
  "Table 3" = table_3
)

ADSL <- synthetic_cdisc_data("latest")$adsl
app <- init(
  data = cdisc_data(
    cdisc_dataset("ADSL", ADSL,
      code = "ADSL <- synthetic_cdisc_data(\"latest\")$adsl",
      metadata = list("Author" = "NEST team", "data_source" = "synthetic data")
    ),
    check = TRUE
  ),
  modules = modules(
    tm_front_page(
      header_text = c(
        "Important information" = "It can go here.",
        "Other information" = "Can go here."
      ),
      tables = table_input,
      additional_tags = HTML("Additional HTML or shiny tags go here <br>"),
      footnotes = c("X" = "is the first footnote", "Y is the second footnote"),
      show_metadata = TRUE
    )
  ),
  header = tags$h1("Sample Application"),
  footer = tags$p("Application footer"),
)

shinyApp(app$ui, app$server)

```