### PR TITLE
[UAT] scale text on the variable browser plot with the plot hieght and width #312

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 * Added `parent_dataname` argument to `tm_variable_browser` and `tm_missing_data` to allow specification of parent dataset for these modules.
 * Improved UI labels and plot panel title in `tm_g_association`.
+* Added inputs `tm_variable_browser` module for text size and plot theme.
 
 # teal.modules.general 0.2.15
 

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -18,6 +18,14 @@
 #'   shown and in what order. Names in the vector have to correspond with datasets names.
 #'   If vector of length zero (default) then all datasets are shown.
 #'
+#' @aliases
+#'   tm_variable_browser_ui,
+#'   tm_variable_browser_srv,
+#'   tm_variable_browser,
+#'   variable_browser_ui,
+#'   variable_browser_srv,
+#'   variable_browser
+#'
 #'
 #' @export
 #'
@@ -104,6 +112,7 @@ ui_variable_browser <- function(id,
 
   shiny::tagList(
     include_css_files("custom"),
+    shinyjs::useShinyjs(),
     teal.widgets::standard_layout(
       output = fluidRow(
         htmlwidgets::getDependency("sparkline"), # needed for sparklines to work
@@ -117,46 +126,35 @@ ui_variable_browser <- function(id,
                 id = ns("tabset_panel"),
                 do.call(
                   tagList,
-                  stats::setNames(
-                    lapply(
-                      datanames,
-                      function(dataname) {
-                        tabPanel(
-                          dataname,
-                          div(
-                            class = "mt-4",
-                            textOutput(ns(paste0("dataset_summary_", dataname)))
-                          ),
-                          div(
-                            class = "mt-4",
-                            teal.widgets::get_dt_rows(
-                              ns(paste0(
-                                "variable_browser_", dataname
-                              )),
-                              ns(
-                                paste0("variable_browser_", dataname, "_rows")
-                              )
-                            ),
-                            DT::dataTableOutput(ns(paste0(
-                              "variable_browser_", dataname
-                            )), width = "100%")
+                  lapply(datanames, function(dataname) {
+                    tabPanel(
+                      dataname,
+                      div(
+                        class = "mt-4",
+                        textOutput(ns(paste0("dataset_summary_", dataname)))
+                      ),
+                      div(
+                        class = "mt-4",
+                        teal.widgets::get_dt_rows(
+                          ns(paste0(
+                            "variable_browser_", dataname
+                          )),
+                          ns(
+                            paste0("variable_browser_", dataname, "_rows")
                           )
-                        )
-                      }
-                    ),
-                    NULL
-                  )
+                        ),
+                        DT::dataTableOutput(ns(paste0(
+                          "variable_browser_", dataname
+                        )), width = "100%")
+                      )
+                    )
+                  })
                 )
               )
             ),
-            { # nolint
-              x <- checkboxInput(ns("show_parent_vars"), "Show parent dataset variables", value = FALSE)
-              if (length(parent_dataname) > 0 && parent_dataname %in% datanames) {
-                x
-              } else {
-                shinyjs::hidden(x)
-              }
-            }
+            shinyjs::hidden({
+              checkboxInput(ns("show_parent_vars"), "Show parent dataset variables", value = FALSE)
+            })
           )
         ),
         column(
@@ -174,6 +172,21 @@ ui_variable_browser <- function(id,
               uiOutput(ns("ui_numeric_display"))
             ),
             teal.widgets::plot_with_settings_ui(ns("variable_plot")),
+            br(),
+            # input user-defined text size
+            teal.widgets::panel_item(
+              title = "Plot settings",
+              collapsed = TRUE,
+              selectInput(inputId = ns("ggplot_theme"), label = "ggplot2 theme",
+                          choices = c("gray", "bw", "linedraw", "light",
+                                      "dark", "minimal", "classic", "void", "test"),
+                          selected = "grey"),
+              fluidRow(
+                column(6, sliderInput(inputId = ns("font_size"), label = "font size",
+                                      min = 5L, max = 30L, value = 15L, step = 1L, ticks = FALSE)),
+                column(6, sliderInput(inputId = ns("label_rotation"), label = "rotate x labels",
+                                      min = 0L, max = 90L, value = 45L, step = 1, ticks = FALSE)))
+              ),
             br(),
             teal.widgets::get_dt_rows(ns("variable_summary_table"), ns("variable_summary_table_rows")),
             DT::dataTableOutput(ns("variable_summary_table"))
@@ -205,10 +218,15 @@ srv_variable_browser <- function(id,
 
     datanames <- names(data)
 
-    if (!identical(datasets_selected, character(0))) {
-      stopifnot(all(datasets_selected %in% datanames))
+    checkmate::assert_character(datasets_selected)
+    checkmate::assert_subset(datasets_selected, datanames)
+    if (length(datasets_selected) != 0L){
       datanames <- datasets_selected
     }
+
+    # conditionally display checkbox
+    shinyjs::toggle(id = "show_parent_vars",
+                    condition = length(parent_dataname) > 0 && parent_dataname %in% datanames)
 
     columns_names <- new.env() # nolint
 
@@ -246,6 +264,24 @@ srv_variable_browser <- function(id,
       columns_names = columns_names,
       plot_var = plot_var
     )
+    # add used-defined text size to ggplot arguments passed from caller frame
+    all_ggplot2_args <- reactive({
+      user_text <- teal.widgets::ggplot2_args(
+        theme = list("text" = ggplot2::element_text(size = input[["font_size"]]),
+                     "axis.text.x" = ggplot2::element_text(angle = input[["label_rotation"]], hjust = 1))
+      )
+      user_theme <- getFromNamespace(sprintf("theme_%s", input[["ggplot_theme"]]), ns = "ggplot2")
+      user_theme <- user_theme()
+      # temporary fix to circumvent assertion issue with resolve_ggplot2_args
+      # drop problematic elements
+      user_theme <- user_theme[grep("strip.text.y.left", names(user_theme), fixed = TRUE, invert = TRUE)]
+
+      teal.widgets::resolve_ggplot2_args(
+        user_plot = user_text,
+        user_default = teal.widgets::ggplot2_args(theme = user_theme),
+        module_plot = ggplot2_args
+      )
+    })
 
     output$ui_numeric_display <- renderUI({
       dataname <- input$tabset_panel
@@ -294,7 +330,8 @@ srv_variable_browser <- function(id,
         unique_entries <- length(unique(df[[varname]]))
         if (unique_entries < .unique_records_for_factor && unique_entries > 0) {
           list(
-            checkboxInput(session$ns("numeric_as_factor"),
+            checkboxInput(
+              session$ns("numeric_as_factor"),
               "Treat variable as factor",
               value = `if`(
                 is.null(isolate(input$numeric_as_factor)),
@@ -422,7 +459,7 @@ srv_variable_browser <- function(id,
         display_density = display_density,
         outlier_definition = outlier_definition,
         records_for_factor = .unique_records_for_factor,
-        ggplot2_args = ggplot2_args
+        ggplot2_args = all_ggplot2_args()
       )
     })
 
@@ -838,6 +875,7 @@ plot_var_summary <- function(var,
                              records_for_factor,
                              ggplot2_args) {
   checkmate::assert_flag(display_density)
+  checkmate::assert_class(ggplot2_args, "ggplot2_args")
 
   grid::grid.newpage()
 
@@ -912,7 +950,9 @@ plot_var_summary <- function(var,
           label = outlier_text,
           x = Inf, y = Inf,
           hjust = 1.02, vjust = 1.2,
-          color = "black"
+          color = "black",
+          # explicitly modify geom text size according
+          size = ggplot2_args[["theme"]][["text"]][["size"]]/3.5
         )
       }
       p
@@ -933,10 +973,9 @@ plot_var_summary <- function(var,
   }
 
   dev_ggplot2_args <- teal.widgets::ggplot2_args(
-    labs = list(x = var_lab),
-    theme = list(axis.text.x = element_text(angle = 45, hjust = 1))
+    labs = list(x = var_lab)
   )
-
+###
   all_ggplot2_args <- teal.widgets::resolve_ggplot2_args(
     ggplot2_args,
     module_plot = dev_ggplot2_args
@@ -947,7 +986,8 @@ plot_var_summary <- function(var,
       # numeric not as factor
       plot_main <- plot_main +
         theme_light() +
-        list(labs = do.call("labs", all_ggplot2_args$labs))
+        list(labs = do.call("labs", all_ggplot2_args$labs),
+             theme = do.call("theme", all_ggplot2_args$theme))
     } else {
       # factor low number of levels OR numeric as factor OR Date
       plot_main <- plot_main +
@@ -1035,12 +1075,12 @@ get_plotted_data <- function(input, plot_var, data) {
 #' @keywords internal
 render_tabset_panel_content <- function(datanames, parent_dataname, output, data, input, columns_names, plot_var) {
   lapply(datanames, render_single_tab,
-    input = input,
-    output = output,
-    data = data,
-    parent_dataname = parent_dataname,
-    columns_names = columns_names,
-    plot_var = plot_var
+         input = input,
+         output = output,
+         data = data,
+         parent_dataname = parent_dataname,
+         columns_names = columns_names,
+         plot_var = plot_var
   )
 }
 

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -177,16 +177,25 @@ ui_variable_browser <- function(id,
             teal.widgets::panel_item(
               title = "Plot settings",
               collapsed = TRUE,
-              selectInput(inputId = ns("ggplot_theme"), label = "ggplot2 theme",
-                          choices = c("gray", "bw", "linedraw", "light",
-                                      "dark", "minimal", "classic", "void", "test"),
-                          selected = "grey"),
-              fluidRow(
-                column(6, sliderInput(inputId = ns("font_size"), label = "font size",
-                                      min = 5L, max = 30L, value = 15L, step = 1L, ticks = FALSE)),
-                column(6, sliderInput(inputId = ns("label_rotation"), label = "rotate x labels",
-                                      min = 0L, max = 90L, value = 45L, step = 1, ticks = FALSE)))
+              selectInput(
+                inputId = ns("ggplot_theme"), label = "ggplot2 theme",
+                choices = c(
+                  "gray", "bw", "linedraw", "light",
+                  "dark", "minimal", "classic", "void", "test"
+                ),
+                selected = "grey"
               ),
+              fluidRow(
+                column(6, sliderInput(
+                  inputId = ns("font_size"), label = "font size",
+                  min = 5L, max = 30L, value = 15L, step = 1L, ticks = FALSE
+                )),
+                column(6, sliderInput(
+                  inputId = ns("label_rotation"), label = "rotate x labels",
+                  min = 0L, max = 90L, value = 45L, step = 1, ticks = FALSE
+                ))
+              )
+            ),
             br(),
             teal.widgets::get_dt_rows(ns("variable_summary_table"), ns("variable_summary_table_rows")),
             DT::dataTableOutput(ns("variable_summary_table"))
@@ -220,13 +229,15 @@ srv_variable_browser <- function(id,
 
     checkmate::assert_character(datasets_selected)
     checkmate::assert_subset(datasets_selected, datanames)
-    if (length(datasets_selected) != 0L){
+    if (length(datasets_selected) != 0L) {
       datanames <- datasets_selected
     }
 
     # conditionally display checkbox
-    shinyjs::toggle(id = "show_parent_vars",
-                    condition = length(parent_dataname) > 0 && parent_dataname %in% datanames)
+    shinyjs::toggle(
+      id = "show_parent_vars",
+      condition = length(parent_dataname) > 0 && parent_dataname %in% datanames
+    )
 
     columns_names <- new.env() # nolint
 
@@ -267,8 +278,10 @@ srv_variable_browser <- function(id,
     # add used-defined text size to ggplot arguments passed from caller frame
     all_ggplot2_args <- reactive({
       user_text <- teal.widgets::ggplot2_args(
-        theme = list("text" = ggplot2::element_text(size = input[["font_size"]]),
-                     "axis.text.x" = ggplot2::element_text(angle = input[["label_rotation"]], hjust = 1))
+        theme = list(
+          "text" = ggplot2::element_text(size = input[["font_size"]]),
+          "axis.text.x" = ggplot2::element_text(angle = input[["label_rotation"]], hjust = 1)
+        )
       )
       user_theme <- getFromNamespace(sprintf("theme_%s", input[["ggplot_theme"]]), ns = "ggplot2")
       user_theme <- user_theme()
@@ -952,7 +965,7 @@ plot_var_summary <- function(var,
           hjust = 1.02, vjust = 1.2,
           color = "black",
           # explicitly modify geom text size according
-          size = ggplot2_args[["theme"]][["text"]][["size"]]/3.5
+          size = ggplot2_args[["theme"]][["text"]][["size"]] / 3.5
         )
       }
       p
@@ -975,7 +988,7 @@ plot_var_summary <- function(var,
   dev_ggplot2_args <- teal.widgets::ggplot2_args(
     labs = list(x = var_lab)
   )
-###
+  ###
   all_ggplot2_args <- teal.widgets::resolve_ggplot2_args(
     ggplot2_args,
     module_plot = dev_ggplot2_args
@@ -986,8 +999,10 @@ plot_var_summary <- function(var,
       # numeric not as factor
       plot_main <- plot_main +
         theme_light() +
-        list(labs = do.call("labs", all_ggplot2_args$labs),
-             theme = do.call("theme", all_ggplot2_args$theme))
+        list(
+          labs = do.call("labs", all_ggplot2_args$labs),
+          theme = do.call("theme", all_ggplot2_args$theme)
+        )
     } else {
       # factor low number of levels OR numeric as factor OR Date
       plot_main <- plot_main +
@@ -1075,12 +1090,12 @@ get_plotted_data <- function(input, plot_var, data) {
 #' @keywords internal
 render_tabset_panel_content <- function(datanames, parent_dataname, output, data, input, columns_names, plot_var) {
   lapply(datanames, render_single_tab,
-         input = input,
-         output = output,
-         data = data,
-         parent_dataname = parent_dataname,
-         columns_names = columns_names,
-         plot_var = plot_var
+    input = input,
+    output = output,
+    data = data,
+    parent_dataname = parent_dataname,
+    columns_names = columns_names,
+    plot_var = plot_var
   )
 }
 

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -2,6 +2,12 @@
 % Please edit documentation in R/tm_variable_browser.R
 \name{tm_variable_browser}
 \alias{tm_variable_browser}
+\alias{tm_variable_browser_ui,}
+\alias{tm_variable_browser_srv,}
+\alias{tm_variable_browser,}
+\alias{variable_browser_ui,}
+\alias{variable_browser_srv,}
+\alias{variable_browser}
 \title{Variable Browser Teal Module}
 \usage{
 tm_variable_browser(


### PR DESCRIPTION
Closes [this issue](https://github.com/insightsengineering/teal.modules.general/issues/312).

Added collapsible slider to allow user to manipulate text size in plots.
Patched applying theme to plots.
Added aliases for module documentation.
