### PR TITLE
hide theoretical distribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 
 ### Bug fixes
 * Fixed a bug in `tm_g_scatterplot` when selected x and y facets were the same.
+* Fixed a bug in `tm_g_distribution` to plot the theoretical distribution with newer `ggplot2` version.
 
 # teal.modules.general 0.2.15
 

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -258,29 +258,32 @@ ui_distribution <- function(id, ...) {
             collapsed = FALSE
           )
         ),
-        teal.widgets::panel_item(
-          "Theoretical Distribution",
-          teal.widgets::optionalSelectInput(
-            ns("t_dist"),
-            div(
-              class = "teal-tooltip",
-              tagList(
-                "Distribution:",
-                icon("circle-info"),
-                span(
-                  class = "tooltiptext",
-                  "Default parameters are optimized with MASS::fitdistr function."
+        conditionalPanel(
+          condition = paste0("input['", ns("main_type"), "'] == 'Density'"),
+          teal.widgets::panel_item(
+            "Theoretical Distribution",
+            teal.widgets::optionalSelectInput(
+              ns("t_dist"),
+              div(
+                class = "teal-tooltip",
+                tagList(
+                  "Distribution:",
+                  icon("circle-info"),
+                  span(
+                    class = "tooltiptext",
+                    "Default parameters are optimized with MASS::fitdistr function."
+                  )
                 )
-              )
+              ),
+              choices = c("normal", "lognormal", "gamma", "unif"),
+              selected = NULL,
+              multiple = FALSE
             ),
-            choices = c("normal", "lognormal", "gamma", "unif"),
-            selected = NULL,
-            multiple = FALSE
-          ),
-          numericInput(ns("dist_param1"), label = "param1", value = NULL),
-          numericInput(ns("dist_param2"), label = "param2", value = NULL),
-          span(actionButton(ns("params_reset"), "Reset params")),
-          collapsed = FALSE
+            numericInput(ns("dist_param1"), label = "param1", value = NULL),
+            numericInput(ns("dist_param2"), label = "param2", value = NULL),
+            span(actionButton(ns("params_reset"), "Reset params")),
+            collapsed = FALSE
+          )
         )
       ),
       teal.widgets::panel_item(

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -707,7 +707,7 @@ srv_distribution <- function(id,
             expr = plot_call + stat_function(
               data = data.frame(x = range(ANL[[dist_var]]), color = mapped_dist),
               aes(x, color = color),
-              fun = mapped_dist,
+              fun = mapped_dist_name,
               n = ndensity,
               size = 2,
               args = params
@@ -717,7 +717,8 @@ srv_distribution <- function(id,
               plot_call = plot_call,
               dist_var = dist_var,
               ndensity = ndensity,
-              mapped_dist = unname(map_dist[t_dist])
+              mapped_dist = unname(map_dist[t_dist]),
+              mapped_dist_name = as.name(unname(map_dist[t_dist]))
             )
           )
         }


### PR DESCRIPTION
Add a conditional to hide `Theoretical distibution` panel when `Frequency` is selected as a plot choice.

EDIT: There is also a warning that is rendered on the main branch when tying to plot the theoretical distribution, this has been fixed by passing a `name` and not a `character` function name to the `fun` argument in `stat_function`.

Please test both cases above with the example app.
