### PR TITLE
Revert square bracket@main

### DIFF
--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -919,7 +919,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
     })
 
     plot_r <- reactive({
-      teal.code::get_var(output_q(), "g")
+      output_q()[["g"]]
     })
 
     pws <- teal.widgets::plot_with_settings_srv(

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -835,8 +835,8 @@ srv_a_regression <- function(id,
     })
 
 
-    fitted <- reactive(teal.code::get_var(output_q(), "fit"))
-    plot_r <- reactive(teal.code::get_var(output_q(), "g"))
+    fitted <- reactive(output_q()[["fit"]])
+    plot_r <- reactive(output_q()[["g"]])
 
     # Insert the plot into a plot_with_settings module from teal.widgets
     pws <- teal.widgets::plot_with_settings_srv(

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -440,7 +440,7 @@ srv_tm_g_association <- function(id,
     )
 
     output$title <- renderText({
-      output_q()[["title"]]
+      teal.code::dev_suppress(output_q()[["title"]])
     })
 
     teal.widgets::verbatim_popup_srv(

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -429,7 +429,7 @@ srv_tm_g_association <- function(id,
 
     plot_r <- shiny::reactive({
       shiny::req(iv_r()$is_valid())
-      teal.code::get_var(output_q(), "p")
+      output_q()[["p"]]
     })
 
     pws <- teal.widgets::plot_with_settings_srv(
@@ -440,7 +440,7 @@ srv_tm_g_association <- function(id,
     )
 
     output$title <- renderText({
-      teal.code::get_var(output_q(), "title")
+      output_q()[["title"]]
     })
 
     teal.widgets::verbatim_popup_srv(

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -594,7 +594,7 @@ srv_g_bivariate <- function(id,
     })
 
     plot_r <- shiny::reactive({
-      teal.code::get_var(output_q(), "p")
+      output_q()[["p"]]
     })
 
     pws <- teal.widgets::plot_with_settings_srv(

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -1168,9 +1168,9 @@ srv_distribution <- function(id,
       qenv_final
     })
 
-    dist_r <- reactive(teal.code::get_var(dist_q(), "g"))
+    dist_r <- reactive(dist_q()[["g"]])
 
-    qq_r <- reactive(teal.code::get_var(qq_q(), "g"))
+    qq_r <- reactive(qq_q()[["g"]])
 
     output$summary_table <- DT::renderDataTable(
       expr = if (iv_r()$is_valid()) common_q()[["summary_table"]] else NULL,

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -451,7 +451,7 @@ srv_g_response <- function(id,
       teal.code::eval_code(qenv, plot_call)
     })
 
-    plot_r <- reactive(teal.code::get_var(output_q(), "p"))
+    plot_r <- reactive(output_q()[["p"]])
 
     # Insert the plot into a plot_with_settings module from teal.widgets
     pws <- teal.widgets::plot_with_settings_srv(

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -893,7 +893,7 @@ srv_g_scatterplot <- function(id,
         teal.code::eval_code(quote(print(p)))
     })
 
-    plot_r <- reactive(teal.code::get_var(output_q(), "p"))
+    plot_r <- reactive(output_q()[["p"]])
 
     # Insert the plot into a plot_with_settings module from teal.widgets
     pws <- teal.widgets::plot_with_settings_srv(
@@ -911,7 +911,7 @@ srv_g_scatterplot <- function(id,
         validate(need(!input$add_density, "Brushing feature is currently not supported when plot has marginal density"))
       }
 
-      merged_data <- isolate(teal.code::get_var(output_q(), "ANL"))
+      merged_data <- isolate(output_q()[["ANL"]])
 
       brushed_df <- teal.widgets::clean_brushedPoints(merged_data, plot_brush)
       numeric_cols <- names(brushed_df)[

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -772,7 +772,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
       )
     })
 
-    summary_plot_r <- reactive(teal.code::get_var(summary_plot_q(), "g"))
+    summary_plot_r <- reactive(summary_plot_q()[["g"]])
 
     combination_cutoff_q <- reactive({
       req(common_code_q())
@@ -938,7 +938,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
       )
     })
 
-    combination_plot_r <- reactive(teal.code::get_var(combination_plot_q(), "g"))
+    combination_plot_r <- reactive(combination_plot_q()[["g"]])
 
     summary_table_q <- reactive({
       req(
@@ -1129,7 +1129,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
         )
     })
 
-    by_subject_plot_r <- reactive(teal.code::get_var(by_subject_plot_q(), "g"))
+    by_subject_plot_r <- reactive(by_subject_plot_q()[["g"]])
 
     output$levels_table <- DT::renderDataTable(
       expr = {

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -900,15 +900,15 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
 
     boxplot_r <- reactive({
       teal::validate_inputs(iv_r())
-      teal.code::get_var(boxplot_q(), "g")
+      boxplot_q()[["g"]]
     })
     density_plot_r <- reactive({
       teal::validate_inputs(iv_r())
-      teal.code::get_var(density_plot_q(), "g")
+      density_plot_q()[["g"]]
     })
     cumulative_plot_r <- reactive({
       teal::validate_inputs(iv_r())
-      teal.code::get_var(cumulative_plot_q(), "g")
+      cumulative_plot_q()[["g"]]
     })
 
     box_pws <- teal.widgets::plot_with_settings_srv(


### PR DESCRIPTION
reverted replace of square bracket by `get_var`. Problem with `get_var` is as follows.

- `get_var(object = qenv(), object = "varname")` is dispatched on `object` and there are variants for `qenv` and `qenv.error`. Sometimes `qenv()` can be a shiny-validation-error which causes error message like `no get_var method for object error bla bla`.
- `[[` is generic exported from base and we have extra `[[.qenv` and `[[.qenverror` and this function have also other variants created in base - so that it doesn't fail when calling `<simpleError>[["varname"]]`

It means that to fix problem of plot printed to devide we need to use `teal.code::supress_dev()` in specific cases. We don't need to depend on a `get_var`