### PR TITLE
561 Allow the selection of a categorical variable in `tm_outliers`

### DIFF
--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -252,13 +252,11 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
   moduleServer(id, function(input, output, session) {
     vars <- list(outlier_var = outlier_var, categorical_var = categorical_var)
 
-    rule_diff <- function(other, other_label, var_label) {
+    rule_diff <- function(other) {
       function(value) {
         othervalue <- tryCatch(selector_list()[[other]]()[["select"]], error = function(e) NULL)
-        if (!is.null(othervalue)) {
-          if (identical(othervalue, value)) {
-            paste0("`", var_label, "` and `", other_label, "` cannot be the same")
-          }
+        if (!is.null(othervalue) && identical(othervalue, value)) {
+          "`Variable` and `Categorical factor` cannot be the same"
         }
       }
     }
@@ -269,9 +267,9 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
       select_validation_rule = list(
         outlier_var = shinyvalidate::compose_rules(
           shinyvalidate::sv_required("Please select a variable"),
-          rule_diff("categorical_var", "Categorical factor", "Variable")
+          rule_diff("categorical_var")
         ),
-        categorical_var = rule_diff("outlier_var", "Variable", "Categorical factor")
+        categorical_var = rule_diff("outlier_var")
       )
     )
 

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -252,12 +252,12 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
   moduleServer(id, function(input, output, session) {
     vars <- list(outlier_var = outlier_var, categorical_var = categorical_var)
 
-    rule_diff <- function(other) {
+    rule_diff <- function(other, other_label, var_label) {
       function(value) {
-        othervalue <- tryCatch(selector_list()[["categorical_var"]]()[["select"]], error = function(e) NULL)
+        othervalue <- tryCatch(selector_list()[[other]]()[["select"]], error = function(e) NULL)
         if (!is.null(othervalue)) {
           if (identical(othervalue, value)) {
-            "`Variable` and `Categorical factor` cannot be the same"
+            paste0("`", var_label, "` and `", other_label, "` cannot be the same")
           }
         }
       }
@@ -269,9 +269,9 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
       select_validation_rule = list(
         outlier_var = shinyvalidate::compose_rules(
           shinyvalidate::sv_required("Please select a variable"),
-          rule_diff("categorical_var")
+          rule_diff("categorical_var", "Categorical factor", "Variable")
         ),
-        categorical_var = rule_diff("outlier_var")
+        categorical_var = rule_diff("outlier_var", "Variable", "Categorical factor")
       )
     )
 


### PR DESCRIPTION
# Pull Request

Fixes #561

### Changes description

Prefer using `other` parameter of the function instead of hardcoded value.

note: The second call of `rule_diff()` is redundant and could be removed, I haven't as it could have been added to prevent some edge case.