### PR TITLE
559 Change order of `Show R code`/`Show warnings` buttons to be consistent with other modules

### DIFF
--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -353,8 +353,8 @@ ui_g_bivariate <- function(id, ...) {
       )
     ),
     forms = tagList(
-      teal.widgets::verbatim_popup_ui(ns("rcode"), "Show R code"),
-      teal.widgets::verbatim_popup_ui(ns("warning"), button_label = "Show Warnings")
+      teal.widgets::verbatim_popup_ui(ns("warning"), button_label = "Show Warnings"),
+      teal.widgets::verbatim_popup_ui(ns("rcode"), "Show R code")
     ),
     pre_output = args$pre_output,
     post_output = args$post_output

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -583,6 +583,7 @@ srv_g_bivariate <- function(id,
             # Add facetting labels
             # optional: grid.newpage() #nolintr
             p <- add_facet_labels(p, xfacet_label = nulled_col_facet_name, yfacet_label = nulled_row_facet_name)
+            grid::grid.newpage()
             grid::grid.draw(p)
           },
           env = list(nulled_col_facet_name = nulled_col_facet_name, nulled_row_facet_name = nulled_row_facet_name)


### PR DESCRIPTION
# Pull Request

- Fixes #559
- Partially implements #560
  - The bug that is described there, not the issue itself

### Changes description

* Small change for outliers module to be consistent with others
* Adds `grid::grid.new.page()` call so that reproducible code prints the plot to a new grid instead of an existing one
  * Very small change that was included on this PR for practicality