### PR TITLE
Unified Visual Consistency for UI Components#564

### DIFF
--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -306,6 +306,7 @@ srv_variable_browser <- function(id,
         fluidRow(
           div(
             class = "col-md-4",
+            br(),
             shinyWidgets::switchInput(
               inputId = session$ns("display_density"),
               label = "Show density",
@@ -317,6 +318,7 @@ srv_variable_browser <- function(id,
           ),
           div(
             class = "col-md-4",
+            br(),
             shinyWidgets::switchInput(
               inputId = session$ns("remove_outliers"),
               label = "Remove outliers",

--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -85,3 +85,12 @@
   height:600px;
   width:100%
 }
+
+/* bootstrap rules */
+.bootstrap-switch .bootstrap-switch-primary {
+    background: #337ab7 !important;
+}
+
+.bootstrap-switch.bootstrap-switch-focused {
+    border-color: #2e6da4 !important;
+}

--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -85,12 +85,3 @@
   height:600px;
   width:100%
 }
-
-/* bootstrap rules */
-.bootstrap-switch .bootstrap-switch-primary {
-    background: #337ab7 !important;
-}
-
-.bootstrap-switch.bootstrap-switch-focused {
-    border-color: #2e6da4 !important;
-}


### PR DESCRIPTION
This fixes https://github.com/insightsengineering/teal.modules.general/issues/564

To ensure a neat and compact arrangement of `switchInput `and `slider`, I've employed a line break. instead of adding new classes. 

<img width="1552" alt="image" src="https://github.com/insightsengineering/teal.modules.general/assets/6700955/add2a595-6cb5-4334-a397-e14d17445fcd">

<img width="1552" alt="image" src="https://github.com/insightsengineering/teal.modules.general/assets/6700955/8b249a91-682e-4173-b5c2-322df234d8a4">


