### PR TITLE
Add tables to `show-r-code` in distribution, scatterplot and outliers modules

### DIFF
--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -648,7 +648,9 @@ srv_distribution <- function(id,
         )
       }
 
-      qenv
+      qenv %>%
+        # used to display table when running show-r-code code
+        teal.code::eval_code(quote(summary_table))
     })
 
     # distplot qenv ----
@@ -1141,7 +1143,9 @@ srv_distribution <- function(id,
             )
           )
         }
-        qenv
+        qenv %>%
+          # used to display table when running show-r-code code
+          teal.code::eval_code(quote(test_stats))
       }
     )
 

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -638,6 +638,7 @@ srv_distribution <- function(id,
                   sd = round(stats::sd(dist_var_name, na.rm = TRUE), roundn),
                   count = dplyr::n()
                 )
+              summary_table # used to display table when running show-r-code code
             },
             env = list(
               dist_var_name = dist_var_name,
@@ -647,10 +648,6 @@ srv_distribution <- function(id,
           )
         )
       }
-
-      qenv %>%
-        # used to display table when running show-r-code code
-        teal.code::eval_code(quote(summary_table))
     })
 
     # distplot qenv ----

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -475,7 +475,8 @@ srv_g_scatterplot <- function(id,
     anl_merged_q <- reactive({
       req(anl_merged_input())
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
+        teal.code::eval_code(quote(ANL)) # used to display table when running show-r-code code
     })
 
     merged <- list(

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -463,7 +463,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         qenv,
         substitute(
           expr = {
-            ANL_OUTLIER_EXTENDED <- dplyr::left_join(
+            ANL_OUTLIER_EXTENDED <- dplyr::left_join(# nolint object_name_linter
               ANL_OUTLIER,
               dplyr::select(
                 dataname,
@@ -1050,11 +1050,11 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         }
 
         display_table$is_outlier_selected <- NULL
-        ANL_OUTLIER_EXTENDED$is_outlier_selected <- NULL
+
         # Extend the brushed ANL_OUTLIER with additional columns
         dplyr::left_join(
           display_table,
-          ANL_OUTLIER_EXTENDED,
+          dplyr::select(ANL_OUTLIER_EXTENDED, -"is_outlier_selected"),
           by = names(display_table)
         ) %>%
           dplyr::select(union(names(display_table), input$table_ui_columns))

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -471,15 +471,15 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
               ),
               by = join_keys
             )
+            # used to display table when running show-r-code code
+            ANL_OUTLIER_EXTENDED[ANL_OUTLIER_EXTENDED$is_outlier_selected, ]
           },
           env = list(
             dataname = as.name(dataname_first),
             join_keys = as.character(get_join_keys(data)$get(dataname_first)[[dataname_first]])
           )
         )
-      ) %>%
-        # used to display table when running show-r-code code
-        teal.code::eval_code(quote(ANL_OUTLIER_EXTENDED[ANL_OUTLIER_EXTENDED$is_outlier_selected, ]))
+      )
 
       if (length(categorical_var) > 0) {
         qenv <- teal.code::eval_code(

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -463,7 +463,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         qenv,
         substitute(
           expr = {
-            ANL_OUTLIER_EXTENDED <- dplyr::left_join(# nolint object_name_linter
+            ANL_OUTLIER_EXTENDED <- dplyr::left_join( # nolint object_name_linter
               ANL_OUTLIER,
               dplyr::select(
                 dataname,

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -471,8 +471,6 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
               ),
               by = join_keys
             )
-            # used to display table when running show-r-code code
-            ANL_OUTLIER_EXTENDED[ANL_OUTLIER_EXTENDED$is_outlier_selected, ]
           },
           env = list(
             dataname = as.name(dataname_first),
@@ -864,13 +862,31 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     final_q <- reactive({
       req(input$tabs)
       tab_type <- input$tabs
-      if (tab_type == "Boxplot") {
+      result_q <- if (tab_type == "Boxplot") {
         boxplot_q()
       } else if (tab_type == "Density Plot") {
         density_plot_q()
       } else if (tab_type == "Cumulative Distribution Plot") {
         cumulative_plot_q()
       }
+      # used to display table when running show-r-code code
+      #  added after the plots so that a change in selected columns doesn't affect
+      #  brush selection.
+      teal.code::eval_code(
+        result_q,
+        substitute(
+          expr = {
+            columns_index <- union(
+              setdiff(names(ANL_OUTLIER), "is_outlier_selected"),
+              table_columns
+            )
+            ANL_OUTLIER_EXTENDED[ANL_OUTLIER_EXTENDED$is_outlier_selected, columns_index]
+          },
+          env = list(
+            table_columns = input$table_ui_columns
+          )
+        )
+      )
     })
 
     # slider text


### PR DESCRIPTION
# Pull Request

Fixes #558

### Changes description

Adds tables to `Show R code` shown on screen for different modules

- `tm_g_distribution`: simple "print" of existing table to qenv
- `tm_g_scatterplot.R`: simple "print" of existing table to qenv
- `tm_outliers.R`
  - Complex change that adds an extended data frame enriched with additional columns shown in table
    - Solution doesn't keep repetitive code
    - Keeps previous workflow as much as it can
  - Possible alternative solution _(easier)_
    - This would just print the ANL_OUTLIERS that only has 6 columns

### How to test

- Run locally the `exploratory` application of `teal.gallery`
- Open the modules and test the module while observing/running the `Show R code`
- Brush selection to see if previous behaviour is kept
  - Filters the table, but not the code
  - Adding selected columns in `Outliers` table won't deselect the data points selection