### PR TITLE
Only retain hard dependencies from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,26 +15,37 @@ repos:
       - id: roxygenize
         name: Regenerate package documentation
         additional_dependencies:
-          - checkmate
-          - digest
-          - dplyr
+          - ggmosaic
           - ggplot2
-          - glue
-          - grDevices
-          - lifecycle
+          - shiny
+          - shinyTree
+          - insightsengineering/teal
+          - checkmate
+          - dplyr
+          - DT
+          - forcats
+          - grid
           - logger
           - magrittr
-          - methods
-          - bioc::MultiAssayExperiment
-          - R6
-          - rlang
-          - rtables
+          - scales
           - shinyjs
+          - shinyvalidate
           - shinyWidgets
           - stats
-          - bioc::SummarizedExperiment
+          - stringr
+          - insightsengineering/teal.code
+          - insightsengineering/teal.data
+          - insightsengineering/teal.logger
+          - insightsengineering/teal.reporter
+          - insightsengineering/teal.slice
+          - insightsengineering/teal.transform
+          - insightsengineering/teal.widgets
+          - tern
+          - tibble
+          - tidyr
+          - tidyselect
           - utils
-          - yaml
+
       - id: spell-check
         name: Check spelling with `spelling`
         exclude: >


### PR DESCRIPTION
# Pull Request

Fixes https://github.com/insightsengineering/coredev-tasks/issues/471

![image](https://github.com/insightsengineering/teal.modules.general/assets/211358/0004716e-564e-4a05-ab7b-9c49a7b3ce36)

### Changes description

- Using GitHub packages for `teal.code`, `teal.logger`, `teal.reporter` _(instead of CRAN)_
  - For consistency across pre-commit
- Had to add `ie/teal.data` as it's not on CRAN yet and it's needed by multiple dependencies 