### PR TITLE
Update docs to use the new `teal_data` instead of `TealData`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
     R (>= 3.6),
     shiny (>= 1.6.0),
     shinyTree,
-    teal (>= 0.14.0)
+    teal (>= 0.14.0.9019)
 Imports:
     checkmate (>= 2.1.0),
     dplyr (>= 1.0.5),
@@ -39,8 +39,8 @@ Imports:
     teal.code (>= 0.4.0),
     teal.logger (>= 0.1.1),
     teal.reporter (>= 0.2.0),
-    teal.slice (>= 0.4.0),
-    teal.transform (>= 0.4.0),
+    teal.slice (>= 0.4.0.9023),
+    teal.transform (>= 0.4.0.9007),
     teal.widgets (>= 0.4.0),
     tern (>= 0.7.10),
     tibble (>= 2.0.0),
@@ -65,7 +65,7 @@ Suggests:
     rlang (>= 1.0.0),
     rtables (>= 0.5.1),
     sparkline,
-    teal.data (>= 0.3.0),
+    teal.data (>= 0.3.0.9010),
     testthat (>= 3.0.4)
 VignetteBuilder:
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.modules.general 0.2.16.9010
 
+### Enhancements
+
+* Updated the package docs and vignettes with the new way of specifying data for `teal::init()`. The `data` argument will accept a `teal_data` object
+
 ### Miscellaneous
 
 * Specified minimal version of package dependencies.

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -258,7 +258,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$choices <- var_labels(data[[response[[i]]$dataname]]())
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
-        unlist(get_join_keys(data)$get(response[[i]]$dataname))
+        unlist(teal.data::get_join_keys(data)$get(response[[i]]$dataname))
       )
     }
 
@@ -324,7 +324,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -31,7 +31,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #' app <- teal::init(
 #'   data = data,
 #'   modules = teal::modules(
@@ -57,7 +57,6 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
-#'
 tm_a_pca <- function(label = "Principal Component Analysis",
                      dat,
                      plot_height = c(600, 200, 2000),
@@ -258,7 +257,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$choices <- var_labels(data[[response[[i]]$dataname]]())
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
-        unlist(teal.data::get_join_keys(data)$get(response[[i]]$dataname))
+        unlist(join_keys(data)[[response[[i]]$dataname]])
       )
     }
 
@@ -324,7 +323,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -40,7 +40,7 @@
 #'       dat = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
-#'           choices = teal.transform::variable_choices(data = data@env$ADSL, c("BMRKR1", "AGE", "EOSDY")),
+#'           choices = teal.transform::variable_choices(data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")),
 #'           selected = c("BMRKR1", "AGE"),
 #'           multiple = TRUE
 #'         ),

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -24,24 +24,23 @@
 #'
 #' # ADSL example
 #'
-#' library(nestcolor)
-#' ADSL <- teal.modules.general::rADSL
-#'
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset(
-#'       "ADSL", ADSL,
-#'       code = "ADSL <- teal.modules.general::rADSL"
-#'     ),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_a_pca(
 #'       "PCA",
 #'       dat = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
-#'           choices = teal.transform::variable_choices(data = ADSL, c("BMRKR1", "AGE", "EOSDY")),
+#'           choices = teal.transform::variable_choices(data = data@env$ADSL, c("BMRKR1", "AGE", "EOSDY")),
 #'           selected = c("BMRKR1", "AGE"),
 #'           multiple = TRUE
 #'         ),

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -257,7 +257,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$choices <- var_labels(data[[response[[i]]$dataname]]())
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
-        unlist(join_keys(data)[[response[[i]]$dataname]])
+        unlist(teal.data::join_keys(data)[[response[[i]]$dataname]])
       )
     }
 
@@ -323,7 +323,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -40,7 +40,9 @@
 #'       dat = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
-#'           choices = teal.transform::variable_choices(data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")),
+#'           choices = teal.transform::variable_choices(
+#'             data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")
+#'           ),
 #'           selected = c("BMRKR1", "AGE"),
 #'           multiple = TRUE
 #'         ),

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -31,7 +31,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #' app <- teal::init(
 #'   data = data,
 #'   modules = teal::modules(

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -34,13 +34,17 @@
 #' # Regression graphs from selected response variable (BMRKR1) and
 #' # selected regressors (AGE)
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_a_regression(
 #'       label = "Regression",
@@ -58,7 +62,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variables:",
-#'           choices = teal.transform::variable_choices(ADSL, c("AGE", "SEX", "RACE")),
+#'           choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
 #'           selected = "AGE",
 #'           multiple = TRUE,
 #'           fixed = FALSE

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -295,7 +295,7 @@ srv_a_regression <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     regression_var <- reactive({

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -41,7 +41,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -295,7 +295,7 @@ srv_a_regression <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     regression_var <- reactive({

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -62,7 +62,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variables:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]], c("AGE", "SEX", "RACE")),
 #'           selected = "AGE",
 #'           multiple = TRUE,
 #'           fixed = FALSE

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -295,7 +295,7 @@ srv_a_regression <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     regression_var <- reactive({

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -41,7 +41,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -32,7 +32,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -25,13 +25,17 @@
 #' @export
 #' @examples
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_data_table(
 #'       variables_selected = list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX")),

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -32,7 +32,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -13,11 +13,14 @@
 #' @export
 #'
 #' @examples
-#' data <- data.frame(1)
+#' data <- teal_data()
+#' data <- within(data, {
+#'   data <- data.frame(1)
+#' })
+#' datanames(data) <- c("data")
+#'
 #' app <- teal::init(
-#'   data = teal_data(
-#'     dataset("data", data)
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_file_viewer(
 #'       input_path = list(

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -24,7 +24,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 #' table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -17,6 +17,15 @@
 #' @export
 #' @examples
 #'
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#'
 #' table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 #' table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))
 #' table_3 <- data.frame(Info = c("E", "F"), Text = c("G", "H"))
@@ -27,15 +36,8 @@
 #'   "Table 3" = table_3
 #' )
 #'
-#' ADSL <- teal.modules.general::rADSL
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL,
-#'       code = "ADSL <- teal.modules.general::rADSL",
-#'       metadata = list("Author" = "NEST team", "data_source" = "synthetic data")
-#'     ),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_front_page(
 #'       header_text = c(

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -24,7 +24,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 #' table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -251,7 +251,7 @@ srv_tm_g_association <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
       selector_list = selector_list,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -43,7 +43,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
 #'           ),
 #'           selected = "RACE",
@@ -55,7 +55,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variables:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
 #'           ),
 #'           selected = "BMRKR2",

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -251,7 +251,7 @@ srv_tm_g_association <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
       selector_list = selector_list,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -32,7 +32,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -251,7 +251,7 @@ srv_tm_g_association <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
       selector_list = selector_list,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -25,14 +25,17 @@
 #' @examples
 #' # Association plot of selected reference variable (SEX)
 #' # against other selected variables (BMRKR1)
-#' library(nestcolor)
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_association(
 #'       ref = teal.transform::data_extract_spec(
@@ -40,7 +43,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
 #'           ),
 #'           selected = "RACE",
@@ -52,7 +55,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variables:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
 #'           ),
 #'           selected = "BMRKR2",

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -32,7 +32,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -45,20 +45,24 @@
 #'
 #' @examples
 #' # Bivariate plot of selected variable (AGE) against selected (SEX)
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_bivariate(
 #'       x = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL),
+#'           choices = teal.transform::variable_choices(data@env$ADSL),
 #'           selected = "AGE",
 #'           fixed = FALSE
 #'         )
@@ -67,7 +71,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL),
+#'           choices = teal.transform::variable_choices(data@env$ADSL),
 #'           selected = "SEX",
 #'           multiple = FALSE,
 #'           fixed = FALSE
@@ -77,7 +81,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL),
+#'           choices = teal.transform::variable_choices(data@env$ADSL),
 #'           selected = "ARM",
 #'           fixed = FALSE
 #'         )
@@ -86,7 +90,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL),
+#'           choices = teal.transform::variable_choices(data@env$ADSL),
 #'           selected = "COUNTRY",
 #'           fixed = FALSE
 #'         )

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -441,7 +441,7 @@ srv_g_bivariate <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -62,7 +62,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]]),
 #'           selected = "AGE",
 #'           fixed = FALSE
 #'         )
@@ -71,7 +71,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]]),
 #'           selected = "SEX",
 #'           multiple = FALSE,
 #'           fixed = FALSE
@@ -81,7 +81,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]]),
 #'           selected = "ARM",
 #'           fixed = FALSE
 #'         )
@@ -90,7 +90,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]]),
 #'           selected = "COUNTRY",
 #'           fixed = FALSE
 #'         )

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -441,7 +441,7 @@ srv_g_bivariate <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -52,7 +52,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -52,7 +52,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -441,7 +441,7 @@ srv_g_bivariate <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -447,7 +447,7 @@ srv_distribution <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -63,7 +63,7 @@
 #' datanames(data) <- datanames
 #' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
-#' vars1 <- choices_selected(variable_choices(data@env$ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
+#' vars1 <- choices_selected(variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")), selected = NULL)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -72,7 +72,7 @@
 #'       dist_var = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
-#'           choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
 #'           selected = "BMRKR1",
 #'           multiple = FALSE,
 #'           fixed = FALSE

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -61,7 +61,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' vars1 <- choices_selected(
 #'   variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),
@@ -447,7 +447,7 @@ srv_distribution <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -61,7 +61,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' vars1 <- choices_selected(
 #'   variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -447,7 +447,7 @@ srv_distribution <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -29,8 +29,15 @@
 #'
 #' @examples
 #' # Example with non-clinical data
+#'
+#' data <- teal_data()
+#' data <- within(data, {
+#'   iris <- iris
+#' })
+#' datanames(data) <- c("iris")
+#'
 #' app <- teal::init(
-#'   data = teal_data(dataset("iris", iris)),
+#'   data = data,
 #'   modules = list(
 #'     teal.modules.general::tm_g_distribution(
 #'       dist_var = teal.transform::data_extract_spec(
@@ -48,22 +55,24 @@
 #' }
 #'
 #' # Example with clinical data
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
-#' vars1 <- choices_selected(variable_choices(ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
+#' vars1 <- choices_selected(variable_choices(data@env$ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL),
-#'     code = "ADSL <- teal.modules.general::rADSL",
-#'     check = FALSE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_distribution(
 #'       dist_var = teal.transform::data_extract_spec(
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
-#'           choices = teal.transform::variable_choices(ADSL, c("AGE", "BMRKR1")),
+#'           choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
 #'           selected = "BMRKR1",
 #'           multiple = FALSE,
 #'           fixed = FALSE

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -63,7 +63,10 @@
 #' datanames(data) <- datanames
 #' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
-#' vars1 <- choices_selected(variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")), selected = NULL)
+#' vars1 <- choices_selected(
+#'   variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),
+#'   selected = NULL
+#' )
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -26,13 +26,19 @@
 #' @export
 #' @examples
 #' # Response plot with selected response (BMRKR1) and selected x variable (RACE)
-#' library(nestcolor)
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+#'     teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
 #'     check = TRUE
 #'   ),
 #'   modules = teal::modules(
@@ -42,7 +48,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL, c("BMRKR2", "COUNTRY")),
+#'           choices = teal.transform::variable_choices(data@env$ADSL, c("BMRKR2", "COUNTRY")),
 #'           selected = "BMRKR2",
 #'           multiple = FALSE,
 #'           fixed = FALSE
@@ -52,7 +58,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(ADSL, c("SEX", "RACE")),
+#'           choices = teal.transform::variable_choices(data@env$ADSL, c("SEX", "RACE")),
 #'           selected = "RACE",
 #'           multiple = FALSE,
 #'           fixed = FALSE

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -275,7 +275,7 @@ srv_g_response <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data)
+      join_keys = teal.data::join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -38,7 +38,7 @@
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+#'     teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
 #'     check = TRUE
 #'   ),
 #'   modules = teal::modules(
@@ -48,7 +48,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL, c("BMRKR2", "COUNTRY")),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]], c("BMRKR2", "COUNTRY")),
 #'           selected = "BMRKR2",
 #'           multiple = FALSE,
 #'           fixed = FALSE
@@ -58,7 +58,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = teal.transform::variable_choices(data@env$ADSL, c("SEX", "RACE")),
+#'           choices = teal.transform::variable_choices(data[["ADSL"]], c("SEX", "RACE")),
 #'           selected = "RACE",
 #'           multiple = FALSE,
 #'           fixed = FALSE

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -34,7 +34,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
@@ -278,7 +278,7 @@ srv_g_response <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data)
+      join_keys = join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -34,7 +34,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -37,10 +37,7 @@
 #' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_response(
 #'       label = "Response Plots",

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -278,7 +278,7 @@ srv_g_response <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data)
+      join_keys = teal.data::get_join_keys(data)
     )
 
     anl_merged_q <- reactive({

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -44,7 +44,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -471,7 +471,7 @@ srv_g_scatterplot <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = join_keys(data),
+      join_keys = teal.data::join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -471,7 +471,7 @@ srv_g_scatterplot <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = get_join_keys(data),
+      join_keys = teal.data::get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -56,7 +56,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("AGE", "BMRKR1", "BMRKR2")
 #'           ),
 #'           selected = "AGE",
@@ -69,7 +69,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("AGE", "BMRKR1", "BMRKR2")
 #'           ),
 #'           selected = "BMRKR1",
@@ -82,7 +82,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,
@@ -95,7 +95,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = "AGE",
@@ -108,7 +108,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,
@@ -121,7 +121,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             data@env$ADSL,
+#'             data[["ADSL"]],
 #'             c("BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -44,7 +44,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -471,7 +471,7 @@ srv_g_scatterplot <- function(id,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data),
+      join_keys = join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -36,15 +36,18 @@
 #' @export
 #' @examples
 #' # Scatterplot of variables from ADSL dataset
-#' library(nestcolor)
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_scatterplot(
 #'       label = "Scatterplot Choices",
@@ -53,7 +56,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("AGE", "BMRKR1", "BMRKR2")
 #'           ),
 #'           selected = "AGE",
@@ -66,7 +69,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("AGE", "BMRKR1", "BMRKR2")
 #'           ),
 #'           selected = "BMRKR1",
@@ -79,7 +82,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,
@@ -92,7 +95,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = "AGE",
@@ -105,7 +108,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,
@@ -118,7 +121,7 @@
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
 #'           choices = teal.transform::variable_choices(
-#'             ADSL,
+#'             data@env$ADSL,
 #'             c("BMRKR2", "RACE", "REGION1")
 #'           ),
 #'           selected = NULL,

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -27,7 +27,7 @@
 #' })
 #' datanames <- c("ADSL", "ADRS")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -180,7 +180,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = teal.data::get_join_keys(data),
+      join_keys = join_keys(data),
       selector_list = selector_list
     )
 

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -27,7 +27,7 @@
 #' })
 #' datanames <- c("ADSL", "ADRS")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -39,7 +39,7 @@
 #'           dataname = "ADSL",
 #'           select = select_spec(
 #'             label = "Select variables:",
-#'             choices = variable_choices(data@env$ADSL),
+#'             choices = variable_choices(data[["ADSL"]]),
 #'             selected = c("AGE", "RACE", "SEX"),
 #'             multiple = TRUE,
 #'             ordered = TRUE,
@@ -51,13 +51,13 @@
 #'           filter = teal.transform::filter_spec(
 #'             label = "Select endpoints:",
 #'             vars = c("PARAMCD", "AVISIT"),
-#'             choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+#'             choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
 #'             selected = "INVET - END OF INDUCTION",
 #'             multiple = TRUE
 #'           ),
 #'           select = select_spec(
 #'             label = "Select variables:",
-#'             choices = variable_choices(data@env$ADRS),
+#'             choices = variable_choices(data[["ADRS"]]),
 #'             selected = c("AGE", "AVAL", "ADY"),
 #'             multiple = TRUE,
 #'             ordered = TRUE,

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -20,15 +20,17 @@
 #' @examples
 #' # Scatterplot matrix of variables from ADSL dataset
 #'
-#' ADSL <- teal.modules.general::rADSL
-#' ADRS <- teal.modules.general::rADRS
+#' data <- teal_data()
+#' data <- within(data, {
+#'   ADSL <- teal.modules.general::rADSL
+#'   ADRS <- teal.modules.general::rADRS
+#' })
+#' datanames <- c("ADSL", "ADRS")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_g_scatterplotmatrix(
 #'       label = "Scatterplot matrix",
@@ -37,7 +39,7 @@
 #'           dataname = "ADSL",
 #'           select = select_spec(
 #'             label = "Select variables:",
-#'             choices = variable_choices(ADSL),
+#'             choices = variable_choices(data@env$ADSL),
 #'             selected = c("AGE", "RACE", "SEX"),
 #'             multiple = TRUE,
 #'             ordered = TRUE,
@@ -49,13 +51,13 @@
 #'           filter = teal.transform::filter_spec(
 #'             label = "Select endpoints:",
 #'             vars = c("PARAMCD", "AVISIT"),
-#'             choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+#'             choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
 #'             selected = "INVET - END OF INDUCTION",
 #'             multiple = TRUE
 #'           ),
 #'           select = select_spec(
 #'             label = "Select variables:",
-#'             choices = variable_choices(ADRS),
+#'             choices = variable_choices(data@env$ADRS),
 #'             selected = c("AGE", "AVAL", "ADY"),
 #'             multiple = TRUE,
 #'             ordered = TRUE,

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -180,7 +180,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = join_keys(data),
+      join_keys = teal.data::join_keys(data),
       selector_list = selector_list
     )
 

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -180,7 +180,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = get_join_keys(data),
+      join_keys = teal.data::get_join_keys(data),
       selector_list = selector_list
     )
 

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -25,7 +25,7 @@
 #' })
 #' datanames <- c("ADSL", "ADRS")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -356,7 +356,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
   moduleServer(id, function(input, output, session) {
     prev_group_by_var <- reactiveVal("")
     data_r <- data[[dataname]]
-    data_keys <- reactive(teal.data::get_join_keys(data)$get(dataname)[[dataname]])
+    data_keys <- reactive(unlist(join_keys(data)[[dataname]]))
 
     iv_r <- reactive({
       iv <- shinyvalidate::InputValidator$new()
@@ -395,7 +395,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
 
     data_parent_keys <- reactive({
       if (length(parent_dataname) > 0 && parent_dataname %in% names(data)) {
-        keys <- teal.data::get_join_keys(data)$get(dataname)
+        keys <- teal.data::join_keys(data)[[dataname]]
         if (parent_dataname %in% names(keys)) {
           keys[[parent_dataname]]
         } else {

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -356,7 +356,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
   moduleServer(id, function(input, output, session) {
     prev_group_by_var <- reactiveVal("")
     data_r <- data[[dataname]]
-    data_keys <- reactive(unlist(join_keys(data)[[dataname]]))
+    data_keys <- reactive(unlist(teal.data::join_keys(data)[[dataname]]))
 
     iv_r <- reactive({
       iv <- shinyvalidate::InputValidator$new()

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -16,17 +16,19 @@
 #' @export
 #'
 #' @examples
-#' library(nestcolor)
 #'
-#' ADSL <- teal.modules.general::rADSL
-#' ADRS <- teal.modules.general::rADRS
+#' data <- teal_data()
+#' data <- within(data, {
+#'   library(nestcolor)
+#'   ADSL <- teal.modules.general::rADSL
+#'   ADRS <- teal.modules.general::rADRS
+#' })
+#' datanames <- c("ADSL", "ADRS")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_missing_data(
 #'       ggplot2_args = list(

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -356,7 +356,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
   moduleServer(id, function(input, output, session) {
     prev_group_by_var <- reactiveVal("")
     data_r <- data[[dataname]]
-    data_keys <- reactive(get_join_keys(data)$get(dataname)[[dataname]])
+    data_keys <- reactive(teal.data::get_join_keys(data)$get(dataname)[[dataname]])
 
     iv_r <- reactive({
       iv <- shinyvalidate::InputValidator$new()
@@ -395,7 +395,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
 
     data_parent_keys <- reactive({
       if (length(parent_dataname) > 0 && parent_dataname %in% names(data)) {
-        keys <- get_join_keys(data)$get(dataname)
+        keys <- teal.data::get_join_keys(data)$get(dataname)
         if (parent_dataname %in% names(keys)) {
           keys[[parent_dataname]]
         } else {

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -25,7 +25,7 @@
 #' })
 #' datanames <- c("ADSL", "ADRS")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -17,16 +17,19 @@
 #'
 #' @examples
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
-#' fact_vars_adsl <- names(Filter(isTRUE, sapply(ADSL, is.factor)))
-#' vars <- choices_selected(variable_choices(ADSL, fact_vars_adsl))
+#' fact_vars_adsl <- names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+#' vars <- choices_selected(variable_choices(data@env$ADSL, fact_vars_adsl))
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_outliers(
 #'       outlier_var = list(
@@ -34,7 +37,7 @@
 #'           dataname = "ADSL",
 #'           select = select_spec(
 #'             label = "Select variable:",
-#'             choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+#'             choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
 #'             selected = "AGE",
 #'             multiple = FALSE,
 #'             fixed = FALSE
@@ -46,8 +49,8 @@
 #'           dataname = "ADSL",
 #'           filter = teal.transform::filter_spec(
 #'             vars = vars,
-#'             choices = value_choices(ADSL, vars$selected),
-#'             selected = value_choices(ADSL, vars$selected),
+#'             choices = value_choices(data@env$ADSL, vars$selected),
+#'             selected = value_choices(data@env$ADSL, vars$selected),
 #'             multiple = TRUE
 #'           )
 #'         )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -23,7 +23,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
 #' vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))
@@ -66,7 +66,6 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
-#'
 tm_outliers <- function(label = "Outliers Module",
                         outlier_var,
                         categorical_var = NULL,
@@ -294,7 +293,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = reactive_select_input,
       datasets = data,
-      join_keys = teal.data::get_join_keys(data),
+      join_keys = join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
@@ -477,7 +476,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           },
           env = list(
             dataname = as.name(dataname_first),
-            join_keys = as.character(teal.data::get_join_keys(data)$get(dataname_first)[[dataname_first]])
+            join_keys = as.character(join_keys(data)[[dataname_first]][[dataname_first]])
           )
         )
       )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -23,7 +23,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
 #' vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -294,7 +294,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = reactive_select_input,
       datasets = data,
-      join_keys = get_join_keys(data),
+      join_keys = teal.data::get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
@@ -477,7 +477,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           },
           env = list(
             dataname = as.name(dataname_first),
-            join_keys = as.character(get_join_keys(data)$get(dataname_first)[[dataname_first]])
+            join_keys = as.character(teal.data::get_join_keys(data)$get(dataname_first)[[dataname_first]])
           )
         )
       )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -476,7 +476,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           },
           env = list(
             dataname = as.name(dataname_first),
-            join_keys = as.character(teal.data::join_keys(data)[[dataname_first]][[dataname_first]])
+            join_keys = as.character(teal.data::join_keys(data)[dataname_first, dataname_first])
           )
         )
       )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -293,7 +293,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = reactive_select_input,
       datasets = data,
-      join_keys = join_keys(data),
+      join_keys = teal.data::join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
@@ -476,7 +476,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           },
           env = list(
             dataname = as.name(dataname_first),
-            join_keys = as.character(join_keys(data)[[dataname_first]][[dataname_first]])
+            join_keys = as.character(teal.data::join_keys(data)[[dataname_first]][[dataname_first]])
           )
         )
       )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -25,8 +25,8 @@
 #' datanames(data) <- datanames
 #' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
-#' fact_vars_adsl <- names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
-#' vars <- choices_selected(variable_choices(data@env$ADSL, fact_vars_adsl))
+#' fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
+#' vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -37,7 +37,7 @@
 #'           dataname = "ADSL",
 #'           select = select_spec(
 #'             label = "Select variable:",
-#'             choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+#'             choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
 #'             selected = "AGE",
 #'             multiple = FALSE,
 #'             fixed = FALSE
@@ -49,8 +49,8 @@
 #'           dataname = "ADSL",
 #'           filter = teal.transform::filter_spec(
 #'             vars = vars,
-#'             choices = value_choices(data@env$ADSL, vars$selected),
-#'             selected = value_choices(data@env$ADSL, vars$selected),
+#'             choices = value_choices(data[["ADSL"]], vars$selected),
+#'             selected = value_choices(data[["ADSL"]], vars$selected),
 #'             multiple = TRUE
 #'           )
 #'         )

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -29,7 +29,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
@@ -75,7 +75,6 @@
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
 #' }
-#'
 tm_t_crosstable <- function(label = "Cross Table",
                             x,
                             y,
@@ -219,7 +218,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = teal.data::get_join_keys(data),
+      join_keys = join_keys(data),
       selector_list = selector_list,
       merge_function = merge_function
     )

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -33,7 +33,7 @@
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+#'     teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
 #'     check = TRUE
 #'   ),
 #'   modules = teal::modules(
@@ -43,7 +43,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = variable_choices(data@env$ADSL, subset = function(data) {
+#'           choices = variable_choices(data[["ADSL"]], subset = function(data) {
 #'             idx <- !vapply(data, inherits, logical(1), c("Date", "POSIXct", "POSIXlt"))
 #'             return(names(data)[idx])
 #'           }),
@@ -57,7 +57,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = variable_choices(data@env$ADSL, subset = function(data) {
+#'           choices = variable_choices(data[["ADSL"]], subset = function(data) {
 #'             idx <- vapply(data, is.factor, logical(1))
 #'             return(names(data)[idx])
 #'           }),

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -219,7 +219,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = get_join_keys(data),
+      join_keys = teal.data::get_join_keys(data),
       selector_list = selector_list,
       merge_function = merge_function
     )

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -32,10 +32,7 @@
 #' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules = teal::modules(
 #'     teal.modules.general::tm_t_crosstable(
 #'       label = "Cross Table",

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -23,11 +23,17 @@
 #' @examples
 #' # Percentage cross table of variables from ADSL dataset
 #'
-#' ADSL <- teal.modules.general::rADSL
+#' data <- teal_data()
+#' data <- within(data, {
+#'   ADSL <- teal.modules.general::rADSL
+#' })
+#' datanames <- c("ADSL")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+#'     teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
 #'     check = TRUE
 #'   ),
 #'   modules = teal::modules(
@@ -37,7 +43,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = variable_choices(ADSL, subset = function(data) {
+#'           choices = variable_choices(data@env$ADSL, subset = function(data) {
 #'             idx <- !vapply(data, inherits, logical(1), c("Date", "POSIXct", "POSIXlt"))
 #'             return(names(data)[idx])
 #'           }),
@@ -51,7 +57,7 @@
 #'         dataname = "ADSL",
 #'         select = teal.transform::select_spec(
 #'           label = "Select variable:",
-#'           choices = variable_choices(ADSL, subset = function(data) {
+#'           choices = variable_choices(data@env$ADSL, subset = function(data) {
 #'             idx <- vapply(data, is.factor, logical(1))
 #'             return(names(data)[idx])
 #'           }),

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -29,7 +29,7 @@
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -215,7 +215,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       datasets = data,
-      join_keys = join_keys(data),
+      join_keys = teal.data::join_keys(data),
       selector_list = selector_list,
       merge_function = merge_function
     )

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -1149,9 +1149,9 @@ render_tab_header <- function(dataset_name, output, data) {
   dataset_ui_id <- paste0("dataset_summary_", dataset_name)
   output[[dataset_ui_id]] <- renderText({
     df <- data[[dataset_name]]()
-    join_keys <- get_join_keys(data)
+    join_keys <- teal.data::get_join_keys(data)
     if (!is.null(join_keys)) {
-      key <- get_join_keys(data)$get(dataset_name)[[dataset_name]]
+      key <- teal.data::get_join_keys(data)$get(dataset_name)[[dataset_name]]
     } else {
       key <- NULL
     }
@@ -1222,7 +1222,7 @@ render_tab_table <- function(dataset_name, parent_dataname, output, data, input,
       # get icons proper for the data types
       icons <- stats::setNames(teal.slice:::variable_types(df), colnames(df))
 
-      join_keys <- get_join_keys(data)
+      join_keys <- teal.data::get_join_keys(data)
       if (!is.null(join_keys)) {
         icons[intersect(join_keys$get(dataset_name)[[dataset_name]], colnames(df))] <- "primary_key"
       }

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -1151,7 +1151,7 @@ render_tab_header <- function(dataset_name, output, data) {
     df <- data[[dataset_name]]()
     join_keys <- join_keys(data)
     if (!is.null(join_keys)) {
-      key <- join_keys(data)[[dataset_name]][[dataset_name]]
+      key <- join_keys(data)[dataset_name, dataset_name]
     } else {
       key <- NULL
     }
@@ -1224,7 +1224,7 @@ render_tab_table <- function(dataset_name, parent_dataname, output, data, input,
 
       join_keys <- join_keys(data)
       if (!is.null(join_keys)) {
-        icons[intersect(join_keys[[dataset_name]][[dataset_name]], colnames(df))] <- "primary_key"
+        icons[intersect(join_keys[dataset_name, dataset_name], colnames(df))] <- "primary_key"
       }
       icons <- variable_type_icons(icons)
 

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -31,15 +31,17 @@
 #'
 #' @examples
 #'
-#' ADSL <- teal.modules.general::rADSL
-#' ADTTE <- teal.modules.general::rADTTE
+#' data <- teal_data()
+#' data <- within(data, {
+#'   ADSL <- teal.modules.general::rADSL
+#'   ADTTE <- teal.modules.general::rADTTE
+#' })
+#' datanames <- c("ADSL", "ADTTE")
+#' datanames(data) <- datanames
+#' data@join_keys <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
-#'   data = teal.data::cdisc_data(
-#'     teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-#'     teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-#'     check = TRUE
-#'   ),
+#'   data = data,
 #'   modules(
 #'     teal.modules.general::tm_variable_browser(
 #'       label = "Variable browser",

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -38,7 +38,7 @@
 #' })
 #' datanames <- c("ADSL", "ADTTE")
 #' datanames(data) <- datanames
-#' join_keys(data) <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- default_cdisc_join_keys[datanames]
 #'
 #' app <- teal::init(
 #'   data = data,

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -38,7 +38,7 @@
 #' })
 #' datanames <- c("ADSL", "ADTTE")
 #' datanames(data) <- datanames
-#' data@join_keys <- cdisc_join_keys(!!!datanames)
+#' join_keys(data) <- cdisc_join_keys(!!!datanames)
 #'
 #' app <- teal::init(
 #'   data = data,
@@ -1149,9 +1149,9 @@ render_tab_header <- function(dataset_name, output, data) {
   dataset_ui_id <- paste0("dataset_summary_", dataset_name)
   output[[dataset_ui_id]] <- renderText({
     df <- data[[dataset_name]]()
-    join_keys <- teal.data::get_join_keys(data)
+    join_keys <- join_keys(data)
     if (!is.null(join_keys)) {
-      key <- teal.data::get_join_keys(data)$get(dataset_name)[[dataset_name]]
+      key <- join_keys(data)[[dataset_name]][[dataset_name]]
     } else {
       key <- NULL
     }
@@ -1222,9 +1222,9 @@ render_tab_table <- function(dataset_name, parent_dataname, output, data, input,
       # get icons proper for the data types
       icons <- stats::setNames(teal.slice:::variable_types(df), colnames(df))
 
-      join_keys <- teal.data::get_join_keys(data)
+      join_keys <- join_keys(data)
       if (!is.null(join_keys)) {
-        icons[intersect(join_keys$get(dataset_name)[[dataset_name]], colnames(df))] <- "primary_key"
+        icons[intersect(join_keys[[dataset_name]][[dataset_name]], colnames(df))] <- "primary_key"
       }
       icons <- variable_type_icons(icons)
 

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -89,7 +89,7 @@ app <- teal::init(
       dat = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
-          choices = teal.transform::variable_choices(data = data@env$ADSL, c("BMRKR1", "AGE", "EOSDY")),
+          choices = teal.transform::variable_choices(data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")),
           selected = c("BMRKR1", "AGE"),
           multiple = TRUE
         ),

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -80,7 +80,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 app <- teal::init(
   data = data,
   modules = teal::modules(

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -89,7 +89,9 @@ app <- teal::init(
       dat = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
-          choices = teal.transform::variable_choices(data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")),
+          choices = teal.transform::variable_choices(
+            data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")
+          ),
           selected = c("BMRKR1", "AGE"),
           multiple = TRUE
         ),

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -73,24 +73,23 @@ Principal component analysis module
 
 # ADSL example
 
-library(nestcolor)
-ADSL <- teal.modules.general::rADSL
-
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset(
-      "ADSL", ADSL,
-      code = "ADSL <- teal.modules.general::rADSL"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_a_pca(
       "PCA",
       dat = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
-          choices = teal.transform::variable_choices(data = ADSL, c("BMRKR1", "AGE", "EOSDY")),
+          choices = teal.transform::variable_choices(data = data@env$ADSL, c("BMRKR1", "AGE", "EOSDY")),
           selected = c("BMRKR1", "AGE"),
           multiple = TRUE
         ),

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -80,7 +80,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 app <- teal::init(
   data = data,
   modules = teal::modules(
@@ -106,5 +106,4 @@ app <- teal::init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
-
 }

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -94,7 +94,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -115,7 +115,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variables:",
-          choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
+          choices = teal.transform::variable_choices(data[["ADSL"]], c("AGE", "SEX", "RACE")),
           selected = "AGE",
           multiple = TRUE,
           fixed = FALSE

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -87,13 +87,17 @@ For more examples, please see the vignette "Using regression plots" via
 # Regression graphs from selected response variable (BMRKR1) and
 # selected regressors (AGE)
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_a_regression(
       label = "Regression",
@@ -111,7 +115,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variables:",
-          choices = teal.transform::variable_choices(ADSL, c("AGE", "SEX", "RACE")),
+          choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
           selected = "AGE",
           multiple = TRUE,
           fixed = FALSE

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -94,7 +94,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -54,13 +54,17 @@ Note though that sorting of numeric columns with \code{NA}/\code{Inf} will be le
 }
 \examples{
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_data_table(
       variables_selected = list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX")),

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -61,7 +61,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -61,7 +61,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_file_viewer.Rd
+++ b/man/tm_file_viewer.Rd
@@ -23,11 +23,14 @@ Supported formats include text formats, \code{PDF}, \code{PNG}, \code{APNG},
 \code{JPEG}, \code{SVG}, \code{WEBP}, \code{GIF} and \code{BMP}.
 }
 \examples{
-data <- data.frame(1)
+data <- teal_data()
+data <- within(data, {
+  data <- data.frame(1)
+})
+datanames(data) <- c("data")
+
 app <- teal::init(
-  data = teal_data(
-    dataset("data", data)
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_file_viewer(
       input_path = list(

--- a/man/tm_front_page.Rd
+++ b/man/tm_front_page.Rd
@@ -47,7 +47,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))

--- a/man/tm_front_page.Rd
+++ b/man/tm_front_page.Rd
@@ -40,6 +40,15 @@ This \code{teal} module creates a simple front page for \code{teal} applications
 }
 \examples{
 
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+
 table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))
 table_3 <- data.frame(Info = c("E", "F"), Text = c("G", "H"))
@@ -50,15 +59,8 @@ table_input <- list(
   "Table 3" = table_3
 )
 
-ADSL <- teal.modules.general::rADSL
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL,
-      code = "ADSL <- teal.modules.general::rADSL",
-      metadata = list("Author" = "NEST team", "data_source" = "synthetic data")
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_front_page(
       header_text = c(

--- a/man/tm_front_page.Rd
+++ b/man/tm_front_page.Rd
@@ -47,7 +47,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
 table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -71,14 +71,17 @@ For more examples, please see the vignette "Using association plot" via
 \examples{
 # Association plot of selected reference variable (SEX)
 # against other selected variables (BMRKR1)
-library(nestcolor)
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_association(
       ref = teal.transform::data_extract_spec(
@@ -86,7 +89,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
           ),
           selected = "RACE",
@@ -98,7 +101,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variables:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
           ),
           selected = "BMRKR2",

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -78,7 +78,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -89,7 +89,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
           ),
           selected = "RACE",
@@ -101,7 +101,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variables:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
           ),
           selected = "BMRKR2",

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -78,7 +78,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -120,7 +120,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -113,20 +113,24 @@ For more examples, please see the vignette "Using bivariate plot" via
 }
 \examples{
 # Bivariate plot of selected variable (AGE) against selected (SEX)
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_bivariate(
       x = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL),
+          choices = teal.transform::variable_choices(data@env$ADSL),
           selected = "AGE",
           fixed = FALSE
         )
@@ -135,7 +139,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL),
+          choices = teal.transform::variable_choices(data@env$ADSL),
           selected = "SEX",
           multiple = FALSE,
           fixed = FALSE
@@ -145,7 +149,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL),
+          choices = teal.transform::variable_choices(data@env$ADSL),
           selected = "ARM",
           fixed = FALSE
         )
@@ -154,7 +158,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL),
+          choices = teal.transform::variable_choices(data@env$ADSL),
           selected = "COUNTRY",
           fixed = FALSE
         )

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -120,7 +120,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -130,7 +130,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL),
+          choices = teal.transform::variable_choices(data[["ADSL"]]),
           selected = "AGE",
           fixed = FALSE
         )
@@ -139,7 +139,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL),
+          choices = teal.transform::variable_choices(data[["ADSL"]]),
           selected = "SEX",
           multiple = FALSE,
           fixed = FALSE
@@ -149,7 +149,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL),
+          choices = teal.transform::variable_choices(data[["ADSL"]]),
           selected = "ARM",
           fixed = FALSE
         )
@@ -158,7 +158,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL),
+          choices = teal.transform::variable_choices(data[["ADSL"]]),
           selected = "COUNTRY",
           fixed = FALSE
         )

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -105,7 +105,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 vars1 <- choices_selected(
   variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -73,8 +73,15 @@ Module to analyze and explore univariate variable distribution
 }
 \examples{
 # Example with non-clinical data
+
+data <- teal_data()
+data <- within(data, {
+  iris <- iris
+})
+datanames(data) <- c("iris")
+
 app <- teal::init(
-  data = teal_data(dataset("iris", iris)),
+  data = data,
   modules = list(
     teal.modules.general::tm_g_distribution(
       dist_var = teal.transform::data_extract_spec(
@@ -92,22 +99,24 @@ if (interactive()) {
 }
 
 # Example with clinical data
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
-vars1 <- choices_selected(variable_choices(ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
+vars1 <- choices_selected(variable_choices(data@env$ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL),
-    code = "ADSL <- teal.modules.general::rADSL",
-    check = FALSE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_distribution(
       dist_var = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
-          choices = teal.transform::variable_choices(ADSL, c("AGE", "BMRKR1")),
+          choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
           selected = "BMRKR1",
           multiple = FALSE,
           fixed = FALSE

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -107,7 +107,7 @@ datanames <- c("ADSL")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
 
-vars1 <- choices_selected(variable_choices(data@env$ADSL, c("ARM", "COUNTRY", "SEX")), selected = NULL)
+vars1 <- choices_selected(variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")), selected = NULL)
 
 app <- teal::init(
   data = data,
@@ -116,7 +116,7 @@ app <- teal::init(
       dist_var = teal.transform::data_extract_spec(
         dataname = "ADSL",
         select = teal.transform::select_spec(
-          choices = teal.transform::variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+          choices = teal.transform::variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
           selected = "BMRKR1",
           multiple = FALSE,
           fixed = FALSE

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -107,7 +107,10 @@ datanames <- c("ADSL")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
 
-vars1 <- choices_selected(variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")), selected = NULL)
+vars1 <- choices_selected(
+  variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),
+  selected = NULL
+)
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -105,7 +105,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 vars1 <- choices_selected(
   variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -93,7 +93,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -93,7 +93,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -96,10 +96,7 @@ datanames(data) <- datanames
 join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_response(
       label = "Response Plots",

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -85,13 +85,19 @@ For more examples, please see the vignette "Using response plot" via
 }
 \examples{
 # Response plot with selected response (BMRKR1) and selected x variable (RACE)
-library(nestcolor)
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+    teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
     check = TRUE
   ),
   modules = teal::modules(
@@ -101,7 +107,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL, c("BMRKR2", "COUNTRY")),
+          choices = teal.transform::variable_choices(data@env$ADSL, c("BMRKR2", "COUNTRY")),
           selected = "BMRKR2",
           multiple = FALSE,
           fixed = FALSE
@@ -111,7 +117,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(ADSL, c("SEX", "RACE")),
+          choices = teal.transform::variable_choices(data@env$ADSL, c("SEX", "RACE")),
           selected = "RACE",
           multiple = FALSE,
           fixed = FALSE

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -97,7 +97,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+    teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
     check = TRUE
   ),
   modules = teal::modules(
@@ -107,7 +107,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL, c("BMRKR2", "COUNTRY")),
+          choices = teal.transform::variable_choices(data[["ADSL"]], c("BMRKR2", "COUNTRY")),
           selected = "BMRKR2",
           multiple = FALSE,
           fixed = FALSE
@@ -117,7 +117,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = teal.transform::variable_choices(data@env$ADSL, c("SEX", "RACE")),
+          choices = teal.transform::variable_choices(data[["ADSL"]], c("SEX", "RACE")),
           selected = "RACE",
           multiple = FALSE,
           fixed = FALSE

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -107,7 +107,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -99,15 +99,18 @@ For more examples, please see the vignette "Using scatterplot" via
 }
 \examples{
 # Scatterplot of variables from ADSL dataset
-library(nestcolor)
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_scatterplot(
       label = "Scatterplot Choices",
@@ -116,7 +119,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("AGE", "BMRKR1", "BMRKR2")
           ),
           selected = "AGE",
@@ -129,7 +132,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("AGE", "BMRKR1", "BMRKR2")
           ),
           selected = "BMRKR1",
@@ -142,7 +145,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,
@@ -155,7 +158,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
           ),
           selected = "AGE",
@@ -168,7 +171,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,
@@ -181,7 +184,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            ADSL,
+            data@env$ADSL,
             c("BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -119,7 +119,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("AGE", "BMRKR1", "BMRKR2")
           ),
           selected = "AGE",
@@ -132,7 +132,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("AGE", "BMRKR1", "BMRKR2")
           ),
           selected = "BMRKR1",
@@ -145,7 +145,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,
@@ -158,7 +158,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("AGE", "BMRKR1", "BMRKR2", "RACE", "REGION1")
           ),
           selected = "AGE",
@@ -171,7 +171,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,
@@ -184,7 +184,7 @@ app <- teal::init(
         select = teal.transform::select_spec(
           label = "Select variable:",
           choices = teal.transform::variable_choices(
-            data@env$ADSL,
+            data[["ADSL"]],
             c("BMRKR2", "RACE", "REGION1")
           ),
           selected = NULL,

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -107,7 +107,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -52,7 +52,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -52,7 +52,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -64,7 +64,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = c("AGE", "RACE", "SEX"),
             multiple = TRUE,
             ordered = TRUE,
@@ -76,13 +76,13 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "INVET - END OF INDUCTION",
             multiple = TRUE
           ),
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADRS),
+            choices = variable_choices(data[["ADRS"]]),
             selected = c("AGE", "AVAL", "ADY"),
             multiple = TRUE,
             ordered = TRUE,

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -45,15 +45,17 @@ For more examples, please see the vignette "Using scatterplot matrix" via
 \examples{
 # Scatterplot matrix of variables from ADSL dataset
 
-ADSL <- teal.modules.general::rADSL
-ADRS <- teal.modules.general::rADRS
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADRS <- teal.modules.general::rADRS
+})
+datanames <- c("ADSL", "ADRS")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_g_scatterplotmatrix(
       label = "Scatterplot matrix",
@@ -62,7 +64,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = c("AGE", "RACE", "SEX"),
             multiple = TRUE,
             ordered = TRUE,
@@ -74,13 +76,13 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "INVET - END OF INDUCTION",
             multiple = TRUE
           ),
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADRS),
+            choices = variable_choices(data@env$ADRS),
             selected = c("AGE", "AVAL", "ADY"),
             multiple = TRUE,
             ordered = TRUE,

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -53,17 +53,19 @@ into context. For example the \code{\link[shiny:helpText]{shiny::helpText()}} el
 Present analysis of missing observations and patients.
 }
 \examples{
-library(nestcolor)
 
-ADSL <- teal.modules.general::rADSL
-ADRS <- teal.modules.general::rADRS
+data <- teal_data()
+data <- within(data, {
+  library(nestcolor)
+  ADSL <- teal.modules.general::rADSL
+  ADRS <- teal.modules.general::rADRS
+})
+datanames <- c("ADSL", "ADRS")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_missing_data(
       ggplot2_args = list(

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -62,7 +62,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -62,7 +62,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -62,7 +62,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
 vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -64,8 +64,8 @@ datanames <- c("ADSL")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
 
-fact_vars_adsl <- names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
-vars <- choices_selected(variable_choices(data@env$ADSL, fact_vars_adsl))
+fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
+vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))
 
 app <- teal::init(
   data = data,
@@ -76,7 +76,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -88,8 +88,8 @@ app <- teal::init(
           dataname = "ADSL",
           filter = teal.transform::filter_spec(
             vars = vars,
-            choices = value_choices(data@env$ADSL, vars$selected),
-            selected = value_choices(data@env$ADSL, vars$selected),
+            choices = value_choices(data[["ADSL"]], vars$selected),
+            selected = value_choices(data[["ADSL"]], vars$selected),
             multiple = TRUE
           )
         )

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -62,7 +62,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
 vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))
@@ -105,5 +105,4 @@ app <- teal::init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
-
 }

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -56,16 +56,19 @@ Module to analyze and identify outliers using different methods
 }
 \examples{
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
-fact_vars_adsl <- names(Filter(isTRUE, sapply(ADSL, is.factor)))
-vars <- choices_selected(variable_choices(ADSL, fact_vars_adsl))
+fact_vars_adsl <- names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+vars <- choices_selected(variable_choices(data@env$ADSL, fact_vars_adsl))
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_outliers(
       outlier_var = list(
@@ -73,7 +76,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -85,8 +88,8 @@ app <- teal::init(
           dataname = "ADSL",
           filter = teal.transform::filter_spec(
             vars = vars,
-            choices = value_choices(ADSL, vars$selected),
-            selected = value_choices(ADSL, vars$selected),
+            choices = value_choices(data@env$ADSL, vars$selected),
+            selected = value_choices(data@env$ADSL, vars$selected),
             multiple = TRUE
           )
         )

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -61,7 +61,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(
@@ -107,5 +107,4 @@ app <- teal::init(
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
-
 }

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -65,7 +65,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+    teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
     check = TRUE
   ),
   modules = teal::modules(
@@ -75,7 +75,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = variable_choices(data@env$ADSL, subset = function(data) {
+          choices = variable_choices(data[["ADSL"]], subset = function(data) {
             idx <- !vapply(data, inherits, logical(1), c("Date", "POSIXct", "POSIXlt"))
             return(names(data)[idx])
           }),
@@ -89,7 +89,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = variable_choices(data@env$ADSL, subset = function(data) {
+          choices = variable_choices(data[["ADSL"]], subset = function(data) {
             idx <- vapply(data, is.factor, logical(1))
             return(names(data)[idx])
           }),

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -61,7 +61,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -55,11 +55,17 @@ For more examples, please see the vignette "Using cross table" via
 \examples{
 # Percentage cross table of variables from ADSL dataset
 
-ADSL <- teal.modules.general::rADSL
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+})
+datanames <- c("ADSL")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
+    teal.data::cdisc_dataset("ADSL", data@env$ADSL, code = "ADSL <- teal.modules.general::rADSL"),
     check = TRUE
   ),
   modules = teal::modules(
@@ -69,7 +75,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = variable_choices(ADSL, subset = function(data) {
+          choices = variable_choices(data@env$ADSL, subset = function(data) {
             idx <- !vapply(data, inherits, logical(1), c("Date", "POSIXct", "POSIXlt"))
             return(names(data)[idx])
           }),
@@ -83,7 +89,7 @@ app <- teal::init(
         dataname = "ADSL",
         select = teal.transform::select_spec(
           label = "Select variable:",
-          choices = variable_choices(ADSL, subset = function(data) {
+          choices = variable_choices(data@env$ADSL, subset = function(data) {
             idx <- vapply(data, is.factor, logical(1))
             return(names(data)[idx])
           }),

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -64,10 +64,7 @@ datanames(data) <- datanames
 join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", data[["ADSL"]], code = "ADSL <- teal.modules.general::rADSL"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     teal.modules.general::tm_t_crosstable(
       label = "Cross Table",

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -63,7 +63,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 
 app <- teal::init(
   data = data,

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -56,15 +56,17 @@ then the default is categorical, otherwise it is numeric).
 }
 \examples{
 
-ADSL <- teal.modules.general::rADSL
-ADTTE <- teal.modules.general::rADTTE
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADTTE <- teal.modules.general::rADTTE
+})
+datanames <- c("ADSL", "ADTTE")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    check = TRUE
-  ),
+  data = data,
   modules(
     teal.modules.general::tm_variable_browser(
       label = "Variable browser",

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -63,7 +63,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
   data = data,

--- a/vignettes/teal-modules-general.Rmd
+++ b/vignettes/teal-modules-general.Rmd
@@ -83,6 +83,7 @@ so both the code and data are stored together.
 Following this, we set the `datanames` and `join_keys`.
 
 ```r
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -91,6 +92,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
+# nolint end
 ```
 
 There is no need to load `teal` as `teal.modules.general` already depends on it.

--- a/vignettes/teal-modules-general.Rmd
+++ b/vignettes/teal-modules-general.Rmd
@@ -51,7 +51,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 # nolint end
 
 app <- teal::init(
@@ -93,7 +93,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 # nolint end
 ```
 

--- a/vignettes/teal-modules-general.Rmd
+++ b/vignettes/teal-modules-general.Rmd
@@ -51,7 +51,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 # nolint end
 
 app <- teal::init(
@@ -93,7 +93,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 # nolint end
 ```
 

--- a/vignettes/teal-modules-general.Rmd
+++ b/vignettes/teal-modules-general.Rmd
@@ -43,6 +43,7 @@ A simple application including a `tm_variable_browser` module could look like th
 ```{r, message = FALSE, results = "hide"}
 library(teal.modules.general)
 
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -51,6 +52,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADTTE")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
+# nolint end
 
 app <- teal::init(
   data = data,

--- a/vignettes/teal-modules-general.Rmd
+++ b/vignettes/teal-modules-general.Rmd
@@ -43,15 +43,17 @@ A simple application including a `tm_variable_browser` module could look like th
 ```{r, message = FALSE, results = "hide"}
 library(teal.modules.general)
 
-ADSL <- teal.modules.general::rADSL # nolint
-ADTTE <- teal.modules.general::rADTTE # nolint
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADTTE <- teal.modules.general::rADTTE
+})
+datanames <- c("ADSL", "ADTTE")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", x = ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADTTE", x = ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     tm_variable_browser(
       label = "Variable browser",
@@ -72,10 +74,25 @@ Let's break the above app into pieces:
 library(teal.modules.general)
 ```
 The line mentioned above imports the library required for this example and loads data from within that library.
+
+Now, we are building a `teal_data` object that will serve as the source of data for the teal app.
+`teal_data` not only encapsulates the data for the app, but it also houses the code required to create the data to maintain reproducibility.
+To do this, we create an empty `teal_data` object and evaluate code to produce the data within the `teal_data` object,
+so both the code and data are stored together.
+
+Following this, we set the `datanames` and `join_keys`.
+
 ```r
-ADSL <- teal.modules.general::rADSL
-ADAE <- teal.modules.general::rADAE
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADTTE <- teal.modules.general::rADTTE
+})
+datanames <- c("ADSL", "ADTTE")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 ```
+
 There is no need to load `teal` as `teal.modules.general` already depends on it.
 
 In the next step, we use `teal` to create `shiny` `ui` and `server` functions so we can launch using `shiny`. The `data`
@@ -84,11 +101,7 @@ argument indicates the modules included in the application. Here, we include onl
 
 ```{r, results = "hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", x = ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADTTE", x = ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    check = TRUE # to check if the code executes to the data provided, x, i.e. ADSL and ADTTE
-  ),
+  data = data,
   modules = teal::modules(
     tm_variable_browser(
       # module name to display in the GUI

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -61,30 +61,28 @@ itself will be constructed by multiple calls of `tm_g_association` using differe
 combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- ADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset(
-      "ADLB",
-      ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     # tm_g_association ----
     modules(
@@ -95,7 +93,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = "AGE",
             fixed = FALSE
           )
@@ -104,7 +102,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = "BMRKR1",
             multiple = TRUE,
             fixed = FALSE
@@ -117,7 +115,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "SEX", "STRATA1", "RACE")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "SEX", "STRATA1", "RACE")),
             selected = "STRATA1",
             multiple = FALSE,
             fixed = FALSE
@@ -127,7 +125,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL2, c("AGE", "SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX", "RACE", "COUNTRY")),
             selected = c("AGE", "COUNTRY", "RACE"),
             multiple = TRUE,
             fixed = FALSE
@@ -140,7 +138,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADTTE),
+            choices = variable_choices(data@env$ADTTE),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -148,7 +146,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = "PARAMCD",
-            choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
             selected = c("PFS", "EFS"),
             multiple = TRUE
           )
@@ -158,7 +156,7 @@ app <- teal::init(
           reshape = TRUE,
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADRS, c("AVALC", "BMRKR1", "BMRKR2", "ARM")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "BMRKR1", "BMRKR2", "ARM")),
             selected = "AVALC",
             multiple = TRUE,
             fixed = FALSE
@@ -167,14 +165,14 @@ app <- teal::init(
             filter_spec(
               label = "Select endpoints:",
               vars = "PARAMCD",
-              choices = value_choices(ADRS, "PARAMCD", "PARAM"),
+              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
               selected = "BESRSPI",
               multiple = TRUE
             ),
             filter_spec(
               label = "Select endpoints:",
               vars = "AVISIT",
-              choices = levels(ADRS$AVISIT),
+              choices = levels(data@env$ADRS$AVISIT),
               selected = "SCREENING",
               multiple = TRUE
             )
@@ -186,7 +184,7 @@ app <- teal::init(
         ref = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVAL", "AVALC")),
+            choices = variable_choices(data@env$ADRS, c("AVAL", "AVALC")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -195,15 +193,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADRS, "PARAMCD", "PARAM"),
-              selected = levels(ADRS$PARAMCD),
+              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADRS$PARAMCD),
               multiple = TRUE,
               label = "Select response"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADRS$AVISIT),
-              selected = levels(ADRS$AVISIT),
+              choices = levels(data@env$ADRS$AVISIT),
+              selected = levels(data@env$ADRS$AVISIT),
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -212,7 +210,7 @@ app <- teal::init(
         vars = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "AGE", "RACE", "COUNTRY", "BMRKR1", "STRATA1", "ARM")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY", "BMRKR1", "STRATA1", "ARM")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE,
@@ -225,7 +223,7 @@ app <- teal::init(
         ref = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS),
+            choices = variable_choices(data@env$ADRS),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -235,7 +233,7 @@ app <- teal::init(
         vars = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS),
+            choices = variable_choices(data@env$ADRS),
             selected = "PARAMCD",
             multiple = TRUE,
             fixed = FALSE,
@@ -250,21 +248,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("AVAL", "CHG2", "PCHG2")),
+            choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2", "PCHG2")),
             selected = "AVAL",
             multiple = FALSE
           )
@@ -274,21 +272,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select labs:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB),
+            choices = variable_choices(data@env$ADLB),
             selected = "STRATA1",
             multiple = TRUE
           )

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -61,6 +61,7 @@ itself will be constructed by multiple calls of `tm_g_association` using differe
 combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -81,6 +82,8 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
+
 app <- teal::init(
   data = data,
   modules = teal::modules(
@@ -93,7 +96,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = "AGE",
             fixed = FALSE
           )
@@ -102,7 +105,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = "BMRKR1",
             multiple = TRUE,
             fixed = FALSE
@@ -115,7 +118,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "SEX", "STRATA1", "RACE")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "SEX", "STRATA1", "RACE")),
             selected = "STRATA1",
             multiple = FALSE,
             fixed = FALSE
@@ -125,7 +128,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL2"]], c("AGE", "SEX", "RACE", "COUNTRY")),
             selected = c("AGE", "COUNTRY", "RACE"),
             multiple = TRUE,
             fixed = FALSE
@@ -138,7 +141,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADTTE),
+            choices = variable_choices(data[["ADTTE"]]),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -146,7 +149,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = "PARAMCD",
-            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
             selected = c("PFS", "EFS"),
             multiple = TRUE
           )
@@ -156,7 +159,7 @@ app <- teal::init(
           reshape = TRUE,
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADRS, c("AVALC", "BMRKR1", "BMRKR2", "ARM")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "BMRKR1", "BMRKR2", "ARM")),
             selected = "AVALC",
             multiple = TRUE,
             fixed = FALSE
@@ -165,14 +168,14 @@ app <- teal::init(
             filter_spec(
               label = "Select endpoints:",
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
+              choices = value_choices(data[["ADRS"]], "PARAMCD", "PARAM"),
               selected = "BESRSPI",
               multiple = TRUE
             ),
             filter_spec(
               label = "Select endpoints:",
               vars = "AVISIT",
-              choices = levels(data@env$ADRS$AVISIT),
+              choices = levels(data[["ADRS"]]$AVISIT),
               selected = "SCREENING",
               multiple = TRUE
             )
@@ -184,7 +187,7 @@ app <- teal::init(
         ref = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVAL", "AVALC")),
+            choices = variable_choices(data[["ADRS"]], c("AVAL", "AVALC")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -193,15 +196,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADRS$PARAMCD),
+              choices = value_choices(data[["ADRS"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADRS"]]$PARAMCD),
               multiple = TRUE,
               label = "Select response"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADRS$AVISIT),
-              selected = levels(data@env$ADRS$AVISIT),
+              choices = levels(data[["ADRS"]]$AVISIT),
+              selected = levels(data[["ADRS"]]$AVISIT),
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -210,7 +213,7 @@ app <- teal::init(
         vars = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY", "BMRKR1", "STRATA1", "ARM")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "AGE", "RACE", "COUNTRY", "BMRKR1", "STRATA1", "ARM")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE,
@@ -223,7 +226,7 @@ app <- teal::init(
         ref = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS),
+            choices = variable_choices(data[["ADRS"]]),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -233,7 +236,7 @@ app <- teal::init(
         vars = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS),
+            choices = variable_choices(data[["ADRS"]]),
             selected = "PARAMCD",
             multiple = TRUE,
             fixed = FALSE,
@@ -248,21 +251,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2", "PCHG2")),
+            choices = variable_choices(data[["ADLB"]], c("AVAL", "CHG2", "PCHG2")),
             selected = "AVAL",
             multiple = FALSE
           )
@@ -272,21 +275,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select labs:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB),
+            choices = variable_choices(data[["ADLB"]]),
             selected = "STRATA1",
             multiple = TRUE
           )

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -78,10 +78,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 
 app <- teal::init(

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -76,9 +76,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -76,9 +76,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 
 app <- teal::init(

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -79,7 +79,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 
 app <- teal::init(

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -78,8 +78,12 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
+
 # nolint end
 
 app <- teal::init(

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -58,8 +58,11 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
 # nolint end
 ```
 

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -56,9 +56,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -41,6 +41,7 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -61,6 +62,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -83,7 +85,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = "BMRKR1",
             fixed = FALSE
           )
@@ -92,7 +94,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE
@@ -102,7 +104,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -112,7 +114,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -125,7 +127,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "AGE", "SEX", "STRATA1", "RACE")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "AGE", "SEX", "STRATA1", "RACE")),
             selected = c("BMRKR1"),
             multiple = FALSE
           )
@@ -134,7 +136,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL2, c("COUNTRY", "AGE", "RACE")),
+            choices = variable_choices(data[["ADSL2"]], c("COUNTRY", "AGE", "RACE")),
             selected = "RACE",
             multiple = FALSE
           )
@@ -143,7 +145,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -153,7 +155,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL2),
+            choices = variable_choices(data[["ADSL2"]]),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -167,12 +169,12 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - END OF INDUCTION",
             multiple = TRUE
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE
           )
@@ -181,7 +183,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADTTE, c("AVAL", "CNSR")),
+            choices = variable_choices(data[["ADTTE"]], c("AVAL", "CNSR")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -189,7 +191,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = c("PARAMCD"),
-            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
             selected = "OS",
             multiple = FALSE
           )
@@ -199,13 +201,13 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - SCREENING",
             multiple = TRUE
           ),
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "COUNTRY", "ARM", "PARAMCD", "AVISIT")),
+            choices = variable_choices(data[["ADRS"]], c("SEX", "RACE", "COUNTRY", "ARM", "PARAMCD", "AVISIT")),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE
@@ -215,7 +217,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -225,7 +227,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -235,7 +237,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -245,7 +247,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -262,21 +264,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADRS$PARAMCD)[1],
+              choices = value_choices(data[["ADRS"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADRS"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select response:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADRS$AVISIT),
-              selected = levels(data@env$ADRS$AVISIT)[1],
+              choices = levels(data[["ADRS"]]$AVISIT),
+              selected = levels(data[["ADRS"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             label = "Select variable:"
@@ -285,7 +287,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
             selected = "BMRKR1",
             multiple = FALSE,
             label = "Select variable:",
@@ -295,7 +297,7 @@ app <- teal::init(
         row_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD")),
+            choices = variable_choices(data[["ADRS"]], c("SEX", "RACE", "ARMCD", "PARAMCD")),
             selected = "SEX",
             multiple = FALSE,
             label = "Select variable:"
@@ -304,7 +306,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD", "AVISIT")),
+            choices = variable_choices(data[["ADRS"]], c("SEX", "RACE", "ARMCD", "PARAMCD", "AVISIT")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -319,21 +321,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADRS$PARAMCD)[1],
+              choices = value_choices(data[["ADRS"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADRS"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select response:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADRS$AVISIT),
-              selected = levels(data@env$ADRS$AVISIT)[1],
+              choices = levels(data[["ADRS"]]$AVISIT),
+              selected = levels(data[["ADRS"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             label = "Select variable:"
@@ -342,7 +344,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -353,15 +355,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -377,7 +379,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "AGE", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -388,7 +390,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -398,7 +400,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -408,7 +410,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -423,7 +425,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -433,7 +435,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "COUNTRY", "ARMCD", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADRS"]], c("SEX", "RACE", "COUNTRY", "ARMCD", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE,
@@ -443,7 +445,7 @@ app <- teal::init(
         row_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVISIT", "PARAMCD")),
+            choices = variable_choices(data[["ADRS"]], c("AVISIT", "PARAMCD")),
             selected = "PARAMCD",
             multiple = FALSE,
             label = "Select variables:"
@@ -452,7 +454,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVISIT", "PARAMCD")),
+            choices = variable_choices(data[["ADRS"]], c("AVISIT", "PARAMCD")),
             selected = "AVISIT",
             multiple = FALSE,
             label = "Select variables:"
@@ -466,15 +468,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -491,15 +493,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -517,21 +519,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select category:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
+            choices = variable_choices(data[["ADLB"]], c("RACE", "SEX", "ARMCD", "ACTARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -543,21 +545,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select category:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
+            choices = variable_choices(data[["ADLB"]], c("RACE", "SEX", "ARMCD", "ACTARMCD")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -568,7 +570,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -578,7 +580,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -588,7 +590,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -41,19 +41,26 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- teal.modules.general::rADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 ```
 
 ## Create an `app` variable
@@ -65,29 +72,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset(
-      "ADLB",
-      ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     # tm_g_bivariate ------
     modules(
@@ -98,7 +83,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = "BMRKR1",
             fixed = FALSE
           )
@@ -107,7 +92,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE
@@ -117,7 +102,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -127,7 +112,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -140,7 +125,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR1", "AGE", "SEX", "STRATA1", "RACE")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "AGE", "SEX", "STRATA1", "RACE")),
             selected = c("BMRKR1"),
             multiple = FALSE
           )
@@ -149,7 +134,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL2, c("COUNTRY", "AGE", "RACE")),
+            choices = variable_choices(data@env$ADSL2, c("COUNTRY", "AGE", "RACE")),
             selected = "RACE",
             multiple = FALSE
           )
@@ -158,7 +143,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -168,7 +153,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL2),
+            choices = variable_choices(data@env$ADSL2),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -182,12 +167,12 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - END OF INDUCTION",
             multiple = TRUE
           ),
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE
           )
@@ -196,7 +181,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADTTE, c("AVAL", "CNSR")),
+            choices = variable_choices(data@env$ADTTE, c("AVAL", "CNSR")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -204,7 +189,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = c("PARAMCD"),
-            choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
             selected = "OS",
             multiple = FALSE
           )
@@ -214,13 +199,13 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoints:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - SCREENING",
             multiple = TRUE
           ),
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADRS, c("SEX", "RACE", "COUNTRY", "ARM", "PARAMCD", "AVISIT")),
+            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "COUNTRY", "ARM", "PARAMCD", "AVISIT")),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE
@@ -230,7 +215,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL, c("SEX", "RACE")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -240,7 +225,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -250,7 +235,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -260,7 +245,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -277,21 +262,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADRS, "PARAMCD", "PARAM"),
-              selected = levels(ADRS$PARAMCD)[1],
+              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADRS$PARAMCD)[1],
               multiple = FALSE,
               label = "Select response:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADRS$AVISIT),
-              selected = levels(ADRS$AVISIT)[1],
+              choices = levels(data@env$ADRS$AVISIT),
+              selected = levels(data@env$ADRS$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             label = "Select variable:"
@@ -300,7 +285,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
             selected = "BMRKR1",
             multiple = FALSE,
             label = "Select variable:",
@@ -310,7 +295,7 @@ app <- teal::init(
         row_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD")),
+            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD")),
             selected = "SEX",
             multiple = FALSE,
             label = "Select variable:"
@@ -319,7 +304,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD", "AVISIT")),
+            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "ARMCD", "PARAMCD", "AVISIT")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -334,21 +319,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADRS, "PARAMCD", "PARAM"),
-              selected = levels(ADRS$PARAMCD)[1],
+              choices = value_choices(data@env$ADRS, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADRS$PARAMCD)[1],
               multiple = FALSE,
               label = "Select response:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADRS$AVISIT),
-              selected = levels(ADRS$AVISIT)[1],
+              choices = levels(data@env$ADRS$AVISIT),
+              selected = levels(data@env$ADRS$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             label = "Select variable:"
@@ -357,7 +342,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "SEX", "AGE", "RACE", "COUNTRY")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -368,15 +353,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -392,7 +377,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -403,7 +388,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -413,7 +398,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -423,7 +408,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -438,7 +423,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVALC", "AVAL")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "AVAL")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = FALSE,
@@ -448,7 +433,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("SEX", "RACE", "COUNTRY", "ARMCD", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADRS, c("SEX", "RACE", "COUNTRY", "ARMCD", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE,
@@ -458,7 +443,7 @@ app <- teal::init(
         row_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVISIT", "PARAMCD")),
+            choices = variable_choices(data@env$ADRS, c("AVISIT", "PARAMCD")),
             selected = "PARAMCD",
             multiple = FALSE,
             label = "Select variables:"
@@ -467,7 +452,7 @@ app <- teal::init(
         col_facet = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVISIT", "PARAMCD")),
+            choices = variable_choices(data@env$ADRS, c("AVISIT", "PARAMCD")),
             selected = "AVISIT",
             multiple = FALSE,
             label = "Select variables:"
@@ -481,15 +466,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -506,15 +491,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -532,21 +517,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select category:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
+            choices = variable_choices(data@env$ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -558,21 +543,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select category:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
+            choices = variable_choices(data@env$ADLB, c("RACE", "SEX", "ARMCD", "ACTARMCD")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -583,7 +568,7 @@ app <- teal::init(
         color = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -593,7 +578,7 @@ app <- teal::init(
         fill = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -603,7 +588,7 @@ app <- teal::init(
         size = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -59,7 +59,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 ```
 

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -56,9 +56,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 ```
 

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -58,10 +58,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```
 

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -29,28 +29,25 @@ library(dplyr) # used to modify data sets
 
 ## Create data sets
 
-Inside this app 5 datasets will be used
+Inside this app 2 datasets will be used
 
 1. `ADSL` A wide data set with subject data
-2. `ADSL2` A wide data set with subject data
-3. `ADRS` A long data set with response data for subjects at different time points of the study
-4. `ADTTE` A long data set with time to event data
-5. `ADLB` A long data set with lab measurements for each subject
+2. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide", echo=2:6}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 ```
 
 ## Create an `app` variable
@@ -62,27 +59,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset("ADLB", ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     modules(
       label = "Cross table",
@@ -92,8 +69,8 @@ app <- teal::init(
           "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
-            selected = names(ADSL)[5],
+            choices = variable_choices(data@env$ADSL),
+            selected = names(data@env$ADSL)[5],
             multiple = TRUE,
             fixed = FALSE,
             ordered = TRUE
@@ -103,8 +80,8 @@ app <- teal::init(
           "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL),
-            selected = names(ADSL)[6],
+            choices = variable_choices(data@env$ADSL),
+            selected = names(data@env$ADSL)[6],
             multiple = FALSE,
             fixed = FALSE
           )
@@ -116,12 +93,12 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-            selected = levels(ADLB$PARAMCD)[1],
+            choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+            selected = levels(data@env$ADLB$PARAMCD)[1],
             multiple = FALSE
           ),
           select = select_spec(
-            choices = variable_choices(ADLB),
+            choices = variable_choices(data@env$ADLB),
             selected = "AVISIT",
             multiple = TRUE,
             fixed = FALSE,
@@ -133,12 +110,12 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-            selected = levels(ADLB$PARAMCD)[1],
+            choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+            selected = levels(data@env$ADLB$PARAMCD)[1],
             multiple = FALSE
           ),
           select = select_spec(
-            choices = variable_choices(ADLB),
+            choices = variable_choices(data@env$ADLB),
             selected = "LOQFL",
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -48,7 +48,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 # nolint end
 ```
 

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -48,7 +48,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 # nolint end
 ```
 

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -35,6 +35,7 @@ Inside this app 2 datasets will be used
 2. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide", echo=2:6}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -48,6 +49,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADLB")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -69,8 +71,8 @@ app <- teal::init(
           "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
-            selected = names(data@env$ADSL)[5],
+            choices = variable_choices(data[["ADSL"]]),
+            selected = names(data[["ADSL"]])[5],
             multiple = TRUE,
             fixed = FALSE,
             ordered = TRUE
@@ -80,8 +82,8 @@ app <- teal::init(
           "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL),
-            selected = names(data@env$ADSL)[6],
+            choices = variable_choices(data[["ADSL"]]),
+            selected = names(data[["ADSL"]])[6],
             multiple = FALSE,
             fixed = FALSE
           )
@@ -93,12 +95,12 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-            selected = levels(data@env$ADLB$PARAMCD)[1],
+            choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+            selected = levels(data[["ADLB"]]$PARAMCD)[1],
             multiple = FALSE
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB),
+            choices = variable_choices(data[["ADLB"]]),
             selected = "AVISIT",
             multiple = TRUE,
             fixed = FALSE,
@@ -110,12 +112,12 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-            selected = levels(data@env$ADLB$PARAMCD)[1],
+            choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+            selected = levels(data[["ADLB"]]$PARAMCD)[1],
             multiple = FALSE
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB),
+            choices = variable_choices(data[["ADLB"]]),
             selected = "LOQFL",
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -35,6 +35,7 @@ Inside this app 3 datasets will be used
 3. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -44,6 +45,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADTTE", "ADLB")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
+# nolint end
 ```
 
 ## Create an `app` variable

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -44,7 +44,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 # nolint end
 ```
 

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -44,7 +44,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 # nolint end
 ```
 

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -35,11 +35,15 @@ Inside this app 3 datasets will be used
 3. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB
+})
+datanames <- c("ADSL", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 ```
 
 ## Create an `app` variable
@@ -50,12 +54,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset("ADLB", ADLB, code = "ADLB <- teal.modules.general::rADLB"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     # two-datasets example
     tm_data_table(

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -45,7 +45,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
 # nolint end
 ```
 

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -36,6 +36,7 @@ Inside this app 5 datasets will be used
 3. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -45,6 +46,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADRS", "ADLB")
 datanames(data) <- datanames
 data@join_keys <- cdisc_join_keys(!!!datanames)
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -67,7 +69,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
             selected = "AGE",
             fixed = FALSE
           )
@@ -77,8 +79,8 @@ app <- teal::init(
           select = select_spec(
             label = "Select variables:",
             choices = variable_choices(
-              data@env$ADSL,
-              subset = names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+              data[["ADSL"]],
+              subset = names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
             ),
             selected = "RACE",
             multiple = FALSE,
@@ -93,7 +95,7 @@ app <- teal::init(
             dataname = "ADSL",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
+              choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
               selected = "AGE",
               fixed = FALSE
             )
@@ -102,7 +104,7 @@ app <- teal::init(
             dataname = "ADLB",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2")),
+              choices = variable_choices(data[["ADLB"]], c("AVAL", "CHG2")),
               selected = "AVAL",
               multiple = FALSE,
               fixed = FALSE
@@ -115,8 +117,8 @@ app <- teal::init(
             select = select_spec(
               label = "Select variables:",
               choices = variable_choices(
-                data@env$ADSL,
-                subset = names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+                data[["ADSL"]],
+                subset = names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
               ),
               selected = "RACE",
               multiple = FALSE,
@@ -131,7 +133,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(data@env$ADRS, c("ADY", "EOSDY")),
+              choices = variable_choices(data[["ADRS"]], c("ADY", "EOSDY")),
               selected = "ADY",
               fixed = FALSE
             )
@@ -140,7 +142,7 @@ app <- teal::init(
             dataname = "ADLB",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2")),
+              choices = variable_choices(data[["ADLB"]], c("AVAL", "CHG2")),
               selected = "AVAL",
               multiple = FALSE,
               fixed = FALSE
@@ -152,7 +154,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(data@env$ADRS, c("ARM", "ACTARM")),
+              choices = variable_choices(data[["ADRS"]], c("ARM", "ACTARM")),
               selected = "ARM",
               multiple = FALSE,
               fixed = FALSE
@@ -163,8 +165,8 @@ app <- teal::init(
             select = select_spec(
               label = "Select variables:",
               choices = variable_choices(
-                data@env$ADLB,
-                subset = names(Filter(isTRUE, sapply(data@env$ADLB, is.factor)))
+                data[["ADLB"]],
+                subset = names(Filter(isTRUE, sapply(data[["ADLB"]], is.factor)))
               ),
               selected = "RACE",
               multiple = FALSE,

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -45,7 +45,7 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADRS", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data) <- default_cdisc_join_keys[datanames]
 # nolint end
 ```
 

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -36,11 +36,15 @@ Inside this app 5 datasets will be used
 3. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADRS <- teal.modules.general::rADRS
-ADLB <- teal.modules.general::rADLB
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADRS <- teal.modules.general::rADRS
+  ADLB <- teal.modules.general::rADLB
+})
+datanames <- c("ADSL", "ADRS", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
 ```
 
 ## Create an `app` variable
@@ -52,12 +56,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADLB", ADLB, code = "ADLB <- teal.modules.general::rADLB"),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     # tm_outliers ----
     modules(
@@ -68,7 +67,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
             selected = "AGE",
             fixed = FALSE
           )
@@ -77,7 +76,10 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL, subset = names(Filter(isTRUE, sapply(ADSL, is.factor)))),
+            choices = variable_choices(
+              data@env$ADSL,
+              subset = names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+            ),
             selected = "RACE",
             multiple = FALSE,
             fixed = FALSE
@@ -91,7 +93,7 @@ app <- teal::init(
             dataname = "ADSL",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(ADSL, c("AGE", "BMRKR1")),
+              choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1")),
               selected = "AGE",
               fixed = FALSE
             )
@@ -100,7 +102,7 @@ app <- teal::init(
             dataname = "ADLB",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(ADLB, c("AVAL", "CHG2")),
+              choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2")),
               selected = "AVAL",
               multiple = FALSE,
               fixed = FALSE
@@ -112,7 +114,10 @@ app <- teal::init(
             dataname = "ADSL",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADSL, subset = names(Filter(isTRUE, sapply(ADSL, is.factor)))),
+              choices = variable_choices(
+                data@env$ADSL,
+                subset = names(Filter(isTRUE, sapply(data@env$ADSL, is.factor)))
+              ),
               selected = "RACE",
               multiple = FALSE,
               fixed = FALSE
@@ -126,7 +131,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(ADRS, c("ADY", "EOSDY")),
+              choices = variable_choices(data@env$ADRS, c("ADY", "EOSDY")),
               selected = "ADY",
               fixed = FALSE
             )
@@ -135,7 +140,7 @@ app <- teal::init(
             dataname = "ADLB",
             select = select_spec(
               label = "Select variable:",
-              choices = variable_choices(ADLB, c("AVAL", "CHG2")),
+              choices = variable_choices(data@env$ADLB, c("AVAL", "CHG2")),
               selected = "AVAL",
               multiple = FALSE,
               fixed = FALSE
@@ -147,7 +152,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADRS, c("ARM", "ACTARM")),
+              choices = variable_choices(data@env$ADRS, c("ARM", "ACTARM")),
               selected = "ARM",
               multiple = FALSE,
               fixed = FALSE
@@ -157,7 +162,10 @@ app <- teal::init(
             dataname = "ADLB",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADLB, subset = names(Filter(isTRUE, sapply(ADLB, is.factor)))),
+              choices = variable_choices(
+                data@env$ADLB,
+                subset = names(Filter(isTRUE, sapply(data@env$ADLB, is.factor)))
+              ),
               selected = "RACE",
               multiple = FALSE,
               fixed = FALSE

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -54,9 +54,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -39,19 +39,26 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- teal.modules.general::rADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 ```
 
 ## Create an `app` variable
@@ -63,27 +70,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset("ADSL2", ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset(
-      "ADLB",
-      ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     modules(
       label = "Regression plots",
@@ -93,7 +80,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -103,7 +90,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE
@@ -117,7 +104,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -127,7 +114,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL2, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX", "RACE")),
             selected = c("AGE", "RACE"),
             multiple = TRUE,
             fixed = FALSE
@@ -141,7 +128,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADTTE, c("AVAL", "CNSR")),
+            choices = variable_choices(data@env$ADTTE, c("AVAL", "CNSR")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -149,7 +136,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select parameter:",
             vars = "PARAMCD",
-            choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
             selected = "PFS",
             multiple = FALSE
           )
@@ -158,14 +145,14 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADTTE, c("AGE", "CNSR", "SEX")),
+            choices = variable_choices(data@env$ADTTE, c("AGE", "CNSR", "SEX")),
             selected = c("AGE", "CNSR", "SEX"),
             multiple = TRUE
           ),
           filter = teal.transform::filter_spec(
             label = "Select parameter:",
             vars = "PARAMCD",
-            choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
             selected = "PFS",
             multiple = FALSE
           )
@@ -178,15 +165,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[2],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[2],
               multiple = TRUE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[2],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[2],
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -203,7 +190,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL, c("BMRKR1", "BMRKR2", "AGE")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2", "AGE")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE
@@ -218,15 +205,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = TRUE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -243,21 +230,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select labs:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("AVAL", "AGE", "BMRKR1", "BMRKR2", "SEX", "ARM")),
+            choices = variable_choices(data@env$ADLB, c("AVAL", "AGE", "BMRKR1", "BMRKR2", "SEX", "ARM")),
             selected = c("AVAL", "BMRKR1"),
             multiple = TRUE
           )

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -57,7 +57,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 ```
 

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -56,8 +56,11 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
 # nolint end
 ```
 

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -39,6 +39,7 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -59,6 +60,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -80,7 +82,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -90,7 +92,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "SEX", "RACE")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE
@@ -104,7 +106,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -114,7 +116,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data[["ADSL2"]], c("AGE", "SEX", "RACE")),
             selected = c("AGE", "RACE"),
             multiple = TRUE,
             fixed = FALSE
@@ -128,7 +130,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADTTE, c("AVAL", "CNSR")),
+            choices = variable_choices(data[["ADTTE"]], c("AVAL", "CNSR")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -136,7 +138,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select parameter:",
             vars = "PARAMCD",
-            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
             selected = "PFS",
             multiple = FALSE
           )
@@ -145,14 +147,14 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADTTE, c("AGE", "CNSR", "SEX")),
+            choices = variable_choices(data[["ADTTE"]], c("AGE", "CNSR", "SEX")),
             selected = c("AGE", "CNSR", "SEX"),
             multiple = TRUE
           ),
           filter = teal.transform::filter_spec(
             label = "Select parameter:",
             vars = "PARAMCD",
-            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
             selected = "PFS",
             multiple = FALSE
           )
@@ -165,15 +167,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[2],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[2],
               multiple = TRUE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[2],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[2],
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -190,7 +192,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2", "AGE")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "BMRKR2", "AGE")),
             selected = "AGE",
             multiple = TRUE,
             fixed = FALSE
@@ -205,15 +207,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = TRUE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = TRUE,
               label = "Select visit:"
             )
@@ -230,21 +232,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select labs:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("AVAL", "AGE", "BMRKR1", "BMRKR2", "SEX", "ARM")),
+            choices = variable_choices(data[["ADLB"]], c("AVAL", "AGE", "BMRKR1", "BMRKR2", "SEX", "ARM")),
             selected = c("AVAL", "BMRKR1"),
             multiple = TRUE
           )

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -56,10 +56,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```
 

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -54,9 +54,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -55,8 +55,11 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
 # nolint end
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -53,9 +53,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -38,6 +38,7 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -58,6 +59,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -79,7 +81,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE
@@ -89,7 +91,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY", "ARMCD", "STRATA1")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "RACE", "COUNTRY", "ARMCD", "STRATA1")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE
@@ -102,7 +104,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE
           )
@@ -125,21 +127,21 @@ app <- teal::init(
             filter_spec(
               label = "Select parameter:",
               vars = "PARAMCD",
-              choices = levels(data@env$ADLB$PARAMCD),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = levels(data[["ADLB"]]$PARAMCD),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE
             ),
             filter_spec(
               label = "Select visit:",
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE
             )
           ),
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data[["ADLB"]], c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE
           )
@@ -150,15 +152,15 @@ app <- teal::init(
             filter_spec(
               label = "Select parameter:",
               vars = "PARAMCD",
-              choices = levels(data@env$ADRS$PARAMCD),
-              selected = levels(data@env$ADRS$PARAMCD)[3],
+              choices = levels(data[["ADRS"]]$PARAMCD),
+              selected = levels(data[["ADRS"]]$PARAMCD)[3],
               multiple = FALSE
             ),
             filter_spec(
               label = "Select visit:",
               vars = "AVISIT",
-              choices = levels(data@env$ADRS$AVISIT),
-              selected = levels(data@env$ADRS$AVISIT)[3],
+              choices = levels(data[["ADRS"]]$AVISIT),
+              selected = levels(data[["ADRS"]]$AVISIT)[3],
               multiple = FALSE
             )
           ),
@@ -182,7 +184,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("SEX", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "COUNTRY")),
             selected = NULL,
             multiple = FALSE
           )
@@ -195,21 +197,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(data@env$ADLB$PARAMCD),
-              selected = levels(data@env$ADLB$PARAMCD)[2],
+              choices = levels(data[["ADLB"]]$PARAMCD),
+              selected = levels(data[["ADLB"]]$PARAMCD)[2],
               multiple = TRUE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[2],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[2],
               multiple = TRUE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data[["ADLB"]], c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE,
@@ -219,7 +221,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(data@env$ADSL, c("ARMCD", "BMRKR1", "BMRKR2", "BEP01FL")),
+            choices = variable_choices(data[["ADSL"]], c("ARMCD", "BMRKR1", "BMRKR2", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE
@@ -231,7 +233,7 @@ app <- teal::init(
         response = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("BMRKR2", "AVALC", "BEP01FL")),
+            choices = variable_choices(data[["ADRS"]], c("BMRKR2", "AVALC", "BEP01FL")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = TRUE,
@@ -241,7 +243,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVALC", "AGE", "SEX", "ARMCD", "STRATA1")),
+            choices = variable_choices(data[["ADRS"]], c("AVALC", "AGE", "SEX", "ARMCD", "STRATA1")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -275,8 +277,8 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = levels(data@env$ADLB$PARAMCD),
-            selected = levels(data@env$ADLB$PARAMCD)[2],
+            choices = levels(data[["ADLB"]]$PARAMCD),
+            selected = levels(data[["ADLB"]]$PARAMCD)[2],
             multiple = FALSE,
             label = "Select lab:"
           ),
@@ -291,13 +293,13 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = levels(data@env$ADLB$PARAMCD),
-            selected = levels(data@env$ADLB$PARAMCD)[1],
+            choices = levels(data[["ADLB"]]$PARAMCD),
+            selected = levels(data[["ADLB"]]$PARAMCD)[1],
             multiple = FALSE,
             label = "Select lab:"
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("AVISIT", "PARAMCD", "BEP01FL")),
+            choices = variable_choices(data[["ADLB"]], c("AVISIT", "PARAMCD", "BEP01FL")),
             selected = "AVISIT",
             multiple = FALSE,
             fixed = TRUE
@@ -308,21 +310,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(data@env$ADLB$PARAMCD),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = levels(data[["ADLB"]]$PARAMCD),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("SEX", "RACE", "ARMCD")),
+            choices = variable_choices(data[["ADLB"]], c("SEX", "RACE", "ARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -334,21 +336,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(data@env$ADLB$PARAMCD),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = levels(data[["ADLB"]]$PARAMCD),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("SEX", "RACE", "ARMCD")),
+            choices = variable_choices(data[["ADLB"]], c("SEX", "RACE", "ARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -38,19 +38,26 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- teal.modules.general::rADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 ```
 
 ## Create an `app` variable
@@ -62,29 +69,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset(
-      "ADLB",
-      ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     modules(
       label = "Response plot",
@@ -94,7 +79,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE
@@ -104,7 +89,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("SEX", "RACE", "COUNTRY", "ARMCD", "STRATA1")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "RACE", "COUNTRY", "ARMCD", "STRATA1")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE
@@ -117,7 +102,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE
           )
@@ -140,21 +125,21 @@ app <- teal::init(
             filter_spec(
               label = "Select parameter:",
               vars = "PARAMCD",
-              choices = levels(ADLB$PARAMCD),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = levels(data@env$ADLB$PARAMCD),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE
             ),
             filter_spec(
               label = "Select visit:",
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE
             )
           ),
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data@env$ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE
           )
@@ -165,15 +150,15 @@ app <- teal::init(
             filter_spec(
               label = "Select parameter:",
               vars = "PARAMCD",
-              choices = levels(ADRS$PARAMCD),
-              selected = levels(ADRS$PARAMCD)[3],
+              choices = levels(data@env$ADRS$PARAMCD),
+              selected = levels(data@env$ADRS$PARAMCD)[3],
               multiple = FALSE
             ),
             filter_spec(
               label = "Select visit:",
               vars = "AVISIT",
-              choices = levels(ADRS$AVISIT),
-              selected = levels(ADRS$AVISIT)[3],
+              choices = levels(data@env$ADRS$AVISIT),
+              selected = levels(data@env$ADRS$AVISIT)[3],
               multiple = FALSE
             )
           ),
@@ -197,7 +182,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("SEX", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "COUNTRY")),
             selected = NULL,
             multiple = FALSE
           )
@@ -210,21 +195,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(ADLB$PARAMCD),
-              selected = levels(ADLB$PARAMCD)[2],
+              choices = levels(data@env$ADLB$PARAMCD),
+              selected = levels(data@env$ADLB$PARAMCD)[2],
               multiple = TRUE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[2],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[2],
               multiple = TRUE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
+            choices = variable_choices(data@env$ADLB, c("BMRKR2", "ITTFL", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE,
@@ -234,7 +219,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADSL",
           select = select_spec(
-            choices = variable_choices(ADSL, c("ARMCD", "BMRKR1", "BMRKR2", "BEP01FL")),
+            choices = variable_choices(data@env$ADSL, c("ARMCD", "BMRKR1", "BMRKR2", "BEP01FL")),
             selected = "BMRKR2",
             multiple = FALSE,
             fixed = FALSE
@@ -246,7 +231,7 @@ app <- teal::init(
         response = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("BMRKR2", "AVALC", "BEP01FL")),
+            choices = variable_choices(data@env$ADRS, c("BMRKR2", "AVALC", "BEP01FL")),
             selected = "AVALC",
             multiple = FALSE,
             fixed = TRUE,
@@ -256,7 +241,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVALC", "AGE", "SEX", "ARMCD", "STRATA1")),
+            choices = variable_choices(data@env$ADRS, c("AVALC", "AGE", "SEX", "ARMCD", "STRATA1")),
             selected = "ARMCD",
             multiple = FALSE,
             fixed = FALSE,
@@ -290,8 +275,8 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = levels(ADLB$PARAMCD),
-            selected = levels(ADLB$PARAMCD)[2],
+            choices = levels(data@env$ADLB$PARAMCD),
+            selected = levels(data@env$ADLB$PARAMCD)[2],
             multiple = FALSE,
             label = "Select lab:"
           ),
@@ -306,13 +291,13 @@ app <- teal::init(
           dataname = "ADLB",
           filter = teal.transform::filter_spec(
             vars = "PARAMCD",
-            choices = levels(ADLB$PARAMCD),
-            selected = levels(ADLB$PARAMCD)[1],
+            choices = levels(data@env$ADLB$PARAMCD),
+            selected = levels(data@env$ADLB$PARAMCD)[1],
             multiple = FALSE,
             label = "Select lab:"
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("AVISIT", "PARAMCD", "BEP01FL")),
+            choices = variable_choices(data@env$ADLB, c("AVISIT", "PARAMCD", "BEP01FL")),
             selected = "AVISIT",
             multiple = FALSE,
             fixed = TRUE
@@ -323,21 +308,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(ADLB$PARAMCD),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = levels(data@env$ADLB$PARAMCD),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("SEX", "RACE", "ARMCD")),
+            choices = variable_choices(data@env$ADLB, c("SEX", "RACE", "ARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -349,21 +334,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = levels(ADLB$PARAMCD),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = levels(data@env$ADLB$PARAMCD),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("SEX", "RACE", "ARMCD")),
+            choices = variable_choices(data@env$ADLB, c("SEX", "RACE", "ARMCD")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -55,10 +55,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -56,7 +56,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -53,9 +53,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -54,9 +54,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -57,7 +57,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -39,19 +39,26 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- teal.modules.general::rADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 ```
 
 ## Create an `app` variable
@@ -63,27 +70,7 @@ combinations of data sets.
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset("ADLB", ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     modules(
       label = "Scatterplot matrix",
@@ -94,7 +81,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL),
+            choices = variable_choices(data@env$ADSL),
             selected = c("AGE", "RACE", "SEX", "BMRKR1", "BMRKR2"),
             multiple = TRUE,
             fixed = FALSE,
@@ -109,7 +96,7 @@ app <- teal::init(
             dataname = "ADSL",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADSL),
+              choices = variable_choices(data@env$ADSL),
               selected = c("AGE", "ACTARM", "SEX", "BMRKR1"),
               multiple = TRUE,
               fixed = FALSE,
@@ -120,7 +107,7 @@ app <- teal::init(
             dataname = "ADSL2",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADSL2),
+              choices = variable_choices(data@env$ADSL2),
               selected = c("COUNTRY", "ACTARM", "STRATA1"),
               multiple = TRUE,
               fixed = FALSE,
@@ -134,7 +121,7 @@ app <- teal::init(
         variables = teal.transform::data_extract_spec(
           dataname = "ADTTE",
           select = select_spec(
-            choices = variable_choices(ADTTE, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADTTE, c("AVAL", "BMRKR1", "BMRKR2")),
             selected = c("AVAL", "BMRKR1", "BMRKR2"),
             multiple = TRUE,
             fixed = FALSE,
@@ -150,7 +137,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADRS),
+              choices = variable_choices(data@env$ADRS),
               selected = c("AVAL", "AVALC"),
               multiple = TRUE,
               fixed = FALSE,
@@ -159,7 +146,7 @@ app <- teal::init(
             filter = teal.transform::filter_spec(
               label = "Select endpoints:",
               vars = c("PARAMCD", "AVISIT"),
-              choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+              choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
               selected = "OVRINV - SCREENING",
               multiple = FALSE
             )
@@ -168,7 +155,7 @@ app <- teal::init(
             dataname = "ADTTE",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(ADTTE),
+              choices = variable_choices(data@env$ADTTE),
               selected = c("AVAL", "CNSR"),
               multiple = TRUE,
               fixed = FALSE,
@@ -177,7 +164,7 @@ app <- teal::init(
             filter = teal.transform::filter_spec(
               label = "Select parameters:",
               vars = "PARAMCD",
-              choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+              choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
               selected = "OS",
               multiple = TRUE
             )

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -39,6 +39,7 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -59,6 +60,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -81,7 +83,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL),
+            choices = variable_choices(data[["ADSL"]]),
             selected = c("AGE", "RACE", "SEX", "BMRKR1", "BMRKR2"),
             multiple = TRUE,
             fixed = FALSE,
@@ -96,7 +98,7 @@ app <- teal::init(
             dataname = "ADSL",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(data@env$ADSL),
+              choices = variable_choices(data[["ADSL"]]),
               selected = c("AGE", "ACTARM", "SEX", "BMRKR1"),
               multiple = TRUE,
               fixed = FALSE,
@@ -107,7 +109,7 @@ app <- teal::init(
             dataname = "ADSL2",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(data@env$ADSL2),
+              choices = variable_choices(data[["ADSL2"]]),
               selected = c("COUNTRY", "ACTARM", "STRATA1"),
               multiple = TRUE,
               fixed = FALSE,
@@ -121,7 +123,7 @@ app <- teal::init(
         variables = teal.transform::data_extract_spec(
           dataname = "ADTTE",
           select = select_spec(
-            choices = variable_choices(data@env$ADTTE, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADTTE"]], c("AVAL", "BMRKR1", "BMRKR2")),
             selected = c("AVAL", "BMRKR1", "BMRKR2"),
             multiple = TRUE,
             fixed = FALSE,
@@ -137,7 +139,7 @@ app <- teal::init(
             dataname = "ADRS",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(data@env$ADRS),
+              choices = variable_choices(data[["ADRS"]]),
               selected = c("AVAL", "AVALC"),
               multiple = TRUE,
               fixed = FALSE,
@@ -146,7 +148,7 @@ app <- teal::init(
             filter = teal.transform::filter_spec(
               label = "Select endpoints:",
               vars = c("PARAMCD", "AVISIT"),
-              choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+              choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
               selected = "OVRINV - SCREENING",
               multiple = FALSE
             )
@@ -155,7 +157,7 @@ app <- teal::init(
             dataname = "ADTTE",
             select = select_spec(
               label = "Select variables:",
-              choices = variable_choices(data@env$ADTTE),
+              choices = variable_choices(data[["ADTTE"]]),
               selected = c("AVAL", "CNSR"),
               multiple = TRUE,
               fixed = FALSE,
@@ -164,7 +166,7 @@ app <- teal::init(
             filter = teal.transform::filter_spec(
               label = "Select parameters:",
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+              choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
               selected = "OS",
               multiple = TRUE
             )

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -56,8 +56,11 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -56,10 +56,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -54,9 +54,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -39,19 +39,26 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
-# nolint start
-ADSL <- teal.modules.general::rADSL
-ADSL2 <- teal.modules.general::rADSL %>%
-  mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
-ADRS <- teal.modules.general::rADRS
-ADTTE <- teal.modules.general::rADTTE
-ADLB <- teal.modules.general::rADLB %>%
-  mutate(CHGC = as.factor(case_when(
-    CHG < 1 ~ "N",
-    CHG > 1 ~ "P",
-    TRUE ~ "-"
-  )))
-# nolint end
+data <- teal_data()
+data <- within(data, {
+  ADSL <- teal.modules.general::rADSL
+  ADSL2 <- teal.modules.general::rADSL %>%
+    mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))
+  ADRS <- teal.modules.general::rADRS
+  ADTTE <- teal.modules.general::rADTTE
+  ADLB <- teal.modules.general::rADLB %>%
+    mutate(CHGC = as.factor(case_when(
+      CHG < 1 ~ "N",
+      CHG > 1 ~ "P",
+      TRUE ~ "-"
+    )))
+})
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+data@join_keys <- cdisc_join_keys(!!!datanames)
+data@join_keys$mutate(
+  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
+)
 ```
 
 ## Create an `app` variable
@@ -69,27 +76,7 @@ ggextra_available <- requireNamespace("ggExtra", quietly = TRUE)
 ```
 ```{r, eval = ggextra_available, echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
 app <- teal::init(
-  data = teal.data::cdisc_data(
-    teal.data::cdisc_dataset("ADSL", ADSL, code = "ADSL <- teal.modules.general::rADSL"),
-    teal.data::cdisc_dataset(
-      "ADSL2",
-      ADSL2,
-      keys = get_cdisc_keys("ADSL"),
-      code = "ADSL2 <- teal.modules.general::rADSL %>%
-              mutate(TRTDUR = round(as.numeric(TRTEDTM - TRTSDTM), 1))"
-    ),
-    teal.data::cdisc_dataset("ADRS", ADRS, code = "ADRS <- teal.modules.general::rADRS"),
-    teal.data::cdisc_dataset("ADTTE", ADTTE, code = "ADTTE <- teal.modules.general::rADTTE"),
-    teal.data::cdisc_dataset("ADLB", ADLB,
-      code = "ADLB <- teal.modules.general::rADLB %>%
-            mutate(CHGC = as.factor(case_when(
-            CHG < 1 ~ 'N',
-            CHG > 1 ~ 'P',
-            TRUE ~ '-'
-            )))"
-    ),
-    check = TRUE
-  ),
+  data = data,
   modules = teal::modules(
     modules(
       label = "Scatterplot",
@@ -99,7 +86,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1", "BMRKR2")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -109,7 +96,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -119,7 +106,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(ADSL, c("RACE", "SEX")),
+            choices = variable_choices(data@env$ADSL, c("RACE", "SEX")),
             selected = NULL,
             multiple = TRUE,
             fixed = FALSE
@@ -133,7 +120,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -143,7 +130,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL2, c("AGE", "SEX")),
+            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -153,7 +140,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL2, c("COUNTRY", "AGE", "RACE")),
+            choices = variable_choices(data@env$ADSL2, c("COUNTRY", "AGE", "RACE")),
             selected = "COUNTRY",
             multiple = FALSE,
             fixed = FALSE
@@ -166,7 +153,7 @@ app <- teal::init(
           dataname = "ADRS",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADRS),
+            choices = variable_choices(data@env$ADRS),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -174,7 +161,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - SCREENING",
             multiple = FALSE
           )
@@ -183,7 +170,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADTTE),
+            choices = variable_choices(data@env$ADTTE),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -191,7 +178,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select parameters:",
             vars = c("PARAMCD"),
-            choices = value_choices(ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
             selected = "OS",
             multiple = TRUE
           )
@@ -200,7 +187,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("AGE", "SEX")),
+            choices = variable_choices(data@env$ADSL, c("AGE", "SEX")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -213,7 +200,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("SEX", "AGE", "BMRKR1", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "BMRKR1", "COUNTRY")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -224,15 +211,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -249,7 +236,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -261,7 +248,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE,
@@ -271,7 +258,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data@env$ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE,
@@ -281,7 +268,7 @@ app <- teal::init(
         color_by = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(ADRS, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data@env$ADRS, c("AGE", "SEX", "RACE")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -296,15 +283,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -321,15 +308,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -346,21 +333,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(ADLB, "PARAMCD", "PARAM"),
-              selected = levels(ADLB$PARAMCD)[1],
+              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
+              selected = levels(data@env$ADLB$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(ADLB$AVISIT),
-              selected = levels(ADLB$AVISIT)[1],
+              choices = levels(data@env$ADLB$AVISIT),
+              selected = levels(data@env$ADLB$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(ADLB, c("RACE", "SEX")),
+            choices = variable_choices(data@env$ADLB, c("RACE", "SEX")),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -54,9 +54,8 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- cdisc_join_keys(!!!datanames)
+datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
 join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -57,7 +57,7 @@ data <- within(data, {
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
 join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
+join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -56,8 +56,11 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
-join_keys(data)[["ADSL2"]][["ADSL2"]] <- c("STUDYID", "USUBJID")
+jk <- default_cdisc_join_keys[datanames]
+jk_adsl2 <- jk
+names(jk_adsl2)[names(jk_adsl2) == "ADSL"] <- "ADSL2"
+jk <- c(jk, jk_adsl2)
+jk["ADSL2", "ADSL"] <- c("USUBJID", "STUDYID")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -56,10 +56,8 @@ data <- within(data, {
 })
 datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
 datanames(data) <- datanames
-data@join_keys <- cdisc_join_keys(!!!datanames)
-data@join_keys$mutate(
-  "ADSL2", "ADSL", get_cdisc_keys("ADSL")
-)
+join_keys(data) <- cdisc_join_keys(!!!datanames)
+join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
 # nolint end
 ```
 

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -39,6 +39,7 @@ Inside this app 5 datasets will be used
 5. `ADLB` A long data set with lab measurements for each subject
 
 ```{r echo=TRUE, message=FALSE, warning=FALSE, results="hide"}
+# nolint start
 data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.general::rADSL
@@ -59,6 +60,7 @@ data@join_keys <- cdisc_join_keys(!!!datanames)
 data@join_keys$mutate(
   "ADSL2", "ADSL", get_cdisc_keys("ADSL")
 )
+# nolint end
 ```
 
 ## Create an `app` variable
@@ -86,7 +88,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1", "BMRKR2")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -96,7 +98,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -106,7 +108,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variables:",
-            choices = variable_choices(data@env$ADSL, c("RACE", "SEX")),
+            choices = variable_choices(data[["ADSL"]], c("RACE", "SEX")),
             selected = NULL,
             multiple = TRUE,
             fixed = FALSE
@@ -120,7 +122,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADSL"]], c("BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE
@@ -130,7 +132,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL2, c("AGE", "SEX")),
+            choices = variable_choices(data[["ADSL2"]], c("AGE", "SEX")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -140,7 +142,7 @@ app <- teal::init(
           dataname = "ADSL2",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL2, c("COUNTRY", "AGE", "RACE")),
+            choices = variable_choices(data[["ADSL2"]], c("COUNTRY", "AGE", "RACE")),
             selected = "COUNTRY",
             multiple = FALSE,
             fixed = FALSE
@@ -153,7 +155,7 @@ app <- teal::init(
           dataname = "ADRS",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADRS),
+            choices = variable_choices(data[["ADRS"]]),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -161,7 +163,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select endpoint:",
             vars = c("PARAMCD", "AVISIT"),
-            choices = value_choices(data@env$ADRS, c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
+            choices = value_choices(data[["ADRS"]], c("PARAMCD", "AVISIT"), c("PARAM", "AVISIT")),
             selected = "OVRINV - SCREENING",
             multiple = FALSE
           )
@@ -170,7 +172,7 @@ app <- teal::init(
           dataname = "ADTTE",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADTTE),
+            choices = variable_choices(data[["ADTTE"]]),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE
@@ -178,7 +180,7 @@ app <- teal::init(
           filter = teal.transform::filter_spec(
             label = "Select parameters:",
             vars = c("PARAMCD"),
-            choices = value_choices(data@env$ADTTE, "PARAMCD", "PARAM"),
+            choices = value_choices(data[["ADTTE"]], "PARAMCD", "PARAM"),
             selected = "OS",
             multiple = TRUE
           )
@@ -187,7 +189,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("AGE", "SEX")),
+            choices = variable_choices(data[["ADSL"]], c("AGE", "SEX")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -200,7 +202,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "BMRKR1", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "AGE", "BMRKR1", "COUNTRY")),
             selected = "AGE",
             multiple = FALSE,
             fixed = FALSE
@@ -211,15 +213,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select measurement:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -236,7 +238,7 @@ app <- teal::init(
           dataname = "ADSL",
           select = select_spec(
             label = "Select variable:",
-            choices = variable_choices(data@env$ADSL, c("SEX", "AGE", "RACE", "COUNTRY")),
+            choices = variable_choices(data[["ADSL"]], c("SEX", "AGE", "RACE", "COUNTRY")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE
@@ -248,7 +250,7 @@ app <- teal::init(
         x = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADRS"]], c("AVAL", "BMRKR1", "BMRKR2")),
             selected = "AVAL",
             multiple = FALSE,
             fixed = FALSE,
@@ -258,7 +260,7 @@ app <- teal::init(
         y = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AVAL", "BMRKR1", "BMRKR2")),
+            choices = variable_choices(data[["ADRS"]], c("AVAL", "BMRKR1", "BMRKR2")),
             selected = "BMRKR1",
             multiple = FALSE,
             fixed = FALSE,
@@ -268,7 +270,7 @@ app <- teal::init(
         color_by = teal.transform::data_extract_spec(
           dataname = "ADRS",
           select = select_spec(
-            choices = variable_choices(data@env$ADRS, c("AGE", "SEX", "RACE")),
+            choices = variable_choices(data[["ADRS"]], c("AGE", "SEX", "RACE")),
             selected = NULL,
             multiple = FALSE,
             fixed = FALSE,
@@ -283,15 +285,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -308,15 +310,15 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
@@ -333,21 +335,21 @@ app <- teal::init(
           filter = list(
             filter_spec(
               vars = "PARAMCD",
-              choices = value_choices(data@env$ADLB, "PARAMCD", "PARAM"),
-              selected = levels(data@env$ADLB$PARAMCD)[1],
+              choices = value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
+              selected = levels(data[["ADLB"]]$PARAMCD)[1],
               multiple = FALSE,
               label = "Select lab:"
             ),
             filter_spec(
               vars = "AVISIT",
-              choices = levels(data@env$ADLB$AVISIT),
-              selected = levels(data@env$ADLB$AVISIT)[1],
+              choices = levels(data[["ADLB"]]$AVISIT),
+              selected = levels(data[["ADLB"]]$AVISIT)[1],
               multiple = FALSE,
               label = "Select visit:"
             )
           ),
           select = select_spec(
-            choices = variable_choices(data@env$ADLB, c("RACE", "SEX")),
+            choices = variable_choices(data[["ADLB"]], c("RACE", "SEX")),
             selected = "SEX",
             multiple = FALSE,
             fixed = FALSE,

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -54,9 +54,10 @@ data <- within(data, {
       TRUE ~ "-"
     )))
 })
-datanames(data) <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
-join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS", "ADTTE", "ADLB")]
-join_keys(data)["ADSL2"] <- get_cdisc_keys("ADSL")
+datanames <- c("ADSL", "ADSL2", "ADRS", "ADTTE", "ADLB")
+datanames(data) <- datanames
+join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data)[["ADSL2"]] <- list(ADSL2 = c("STUDYID", "USUBJID"))
 # nolint end
 ```
 


### PR DESCRIPTION
Closes #591 and also use the new `join_keys` functions and methods part of the [teal.data PR #184](https://github.com/insightsengineering/teal.data/pull/184)