### PR TITLE
`tdata` to `teal_data` - `tm_a_pca`

### DIFF
--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -255,7 +255,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$multiple <- FALSE
       response[[i]]$select$always_selected <- NULL
       response[[i]]$select$selected <- NULL
-      response[[i]]$select$choices <- var_labels(data()[[response[[i]]$dataname]])
+      response[[i]]$select$choices <- var_labels(isolate(data())[[response[[i]]$dataname]])
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
         unlist(teal.data::join_keys(data())[[response[[i]]$dataname]])

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -246,7 +246,8 @@ ui_a_pca <- function(id, ...) {
 srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, plot_width, ggplot2_args) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
-  checkmate::assert_class(data, "tdata")
+  checkmate::assert_class(data, "reactive")
+  checkmate::assert_class(isolate(data()), "teal_data")
   moduleServer(id, function(input, output, session) {
     response <- dat
 
@@ -254,10 +255,10 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$multiple <- FALSE
       response[[i]]$select$always_selected <- NULL
       response[[i]]$select$selected <- NULL
-      response[[i]]$select$choices <- var_labels(data[[response[[i]]$dataname]]())
+      response[[i]]$select$choices <- var_labels(data()[[response[[i]]$dataname]])
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
-        unlist(teal.data::join_keys(data)[[response[[i]]$dataname]])
+        unlist(teal.data::join_keys(data())[[response[[i]]$dataname]])
       )
     }
 
@@ -322,13 +323,12 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
 
     anl_merged_input <- teal.transform::merge_expression_srv(
       selector_list = selector_list,
-      datasets = data,
-      join_keys = teal.data::join_keys(data)
+      datasets = data
     )
 
     anl_merged_q <- reactive({
       req(anl_merged_input())
-      teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
+      data() %>%
         teal.code::eval_code(as.expression(anl_merged_input()$expr))
     })
 

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -258,7 +258,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       response[[i]]$select$choices <- var_labels(isolate(data())[[response[[i]]$dataname]])
       response[[i]]$select$choices <- setdiff(
         response[[i]]$select$choices,
-        unlist(teal.data::join_keys(data())[[response[[i]]$dataname]])
+        unlist(teal.data::join_keys(isolate(data()))[[response[[i]]$dataname]])
       )
     }
 


### PR DESCRIPTION
**Example App**

```
data <- teal_data()
data <- within(data, {
  library(nestcolor)
  ADSL <- teal.modules.general::rADSL
})
datanames <- c("ADSL")
datanames(data) <- datanames
join_keys(data) <- default_cdisc_join_keys[datanames]
app <- teal::init(
  data = data,
  modules = teal::modules(
    teal.modules.general::tm_a_pca(
      "PCA",
      dat = teal.transform::data_extract_spec(
        dataname = "ADSL",
        select = teal.transform::select_spec(
          choices = teal.transform::variable_choices(
            data = data[["ADSL"]], c("BMRKR1", "AGE", "EOSDY")
          ),
          selected = c("BMRKR1", "AGE"),
          multiple = TRUE
        ),
        filter = NULL
      ),
      ggplot2_args = teal.widgets::ggplot2_args(
        labs = list(subtitle = "Plot generated by PCA Module")
      )
    )
  )
)

shinyApp(app$ui, app$server)
```