### PR TITLE
`tdata` to `teal_data` - `tm_t_crosstable`

### DIFF
--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -167,7 +167,8 @@ get_footer_tags <- function(footnotes) {
 }
 
 srv_front_page <- function(id, data, tables, show_metadata) {
-  checkmate::assert_class(data, "tdata")
+  checkmate::assert_class(data, "reactive")
+  checkmate::assert_class(isolate(data()), "teal_data")
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -193,9 +194,10 @@ srv_front_page <- function(id, data, tables, show_metadata) {
       )
 
       metadata_data_frame <- reactive({
+        datanames <- teal.data::datanames(data())
         convert_metadata_to_dataframe(
-          lapply(names(data), function(dataname) get_metadata(data, dataname)),
-          names(data)
+          lapply(datanames, function(dataname) dataname), #TODO,
+          datanames
         )
       })
 

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -21,6 +21,7 @@
 #' data <- within(data, {
 #'   library(nestcolor)
 #'   ADSL <- teal.modules.general::rADSL
+#'   attr(ADSL, "metadata") <- list("Author" = "NEST team", "data_source" = "synthetic data")
 #' })
 #' datanames <- c("ADSL")
 #' datanames(data) <- datanames
@@ -196,7 +197,7 @@ srv_front_page <- function(id, data, tables, show_metadata) {
       metadata_data_frame <- reactive({
         datanames <- teal.data::datanames(data())
         convert_metadata_to_dataframe(
-          lapply(datanames, function(dataname) dataname), #TODO,
+          lapply(datanames, function(dataname) attr(data()[[dataname]], "metadata")),
           datanames
         )
       })


### PR DESCRIPTION
Example App

```
data <- teal_data()
data <- within(data, {
  library(nestcolor)
  ADSL <- teal.modules.general::rADSL
  attr(ADSL, "metadata") <- list("Author" = "NEST team", "data_source" = "synthetic data")
})
datanames <- c("ADSL")
datanames(data) <- datanames
join_keys(data) <- default_cdisc_join_keys[datanames]

table_1 <- data.frame(Info = c("A", "B"), Text = c("A", "B"))
table_2 <- data.frame(`Column 1` = c("C", "D"), `Column 2` = c(5.5, 6.6), `Column 3` = c("A", "B"))
table_3 <- data.frame(Info = c("E", "F"), Text = c("G", "H"))

table_input <- list(
  "Table 1" = table_1,
  "Table 2" = table_2,
  "Table 3" = table_3
)

app <- teal::init(
  data = data,
  modules = teal::modules(
    teal.modules.general::tm_front_page(
      header_text = c(
        "Important information" = "It can go here.",
        "Other information" = "Can go here."
      ),
      tables = table_input,
      additional_tags = HTML("Additional HTML or shiny tags go here <br>"),
      footnotes = c("X" = "is the first footnote", "Y is the second footnote"),
      show_metadata = TRUE
    )
  ),
  header = tags$h1("Sample Application"),
  footer = tags$p("Application footer"),
)

shinyApp(app$ui, app$server)
```
