### PR TITLE
619 update modules to handle default datanames when datanames = "all"

### DIFF
--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -1,6 +1,7 @@
 #' Data Table Viewer Teal Module
 #'
 #' A data table viewer shows the data using a paginated table.
+#' specifically designed for use with `data.frames`.
 #' @md
 #'
 #' @inheritParams teal::module
@@ -12,6 +13,8 @@
 #' @param datasets_selected (`character`) A vector of datasets which should be
 #'   shown and in what order. Names in the vector have to correspond with datasets names.
 #'   If vector of length zero (default) then all datasets are shown.
+#'   Note: Only datasets of the `data.frame` class are compatible;
+#'   using other types will cause an error.
 #' @param dt_args (named `list`) Additional arguments to be passed to `DT::datatable`
 #'   (must not include `data` or `options`).
 #' @param dt_options (named `list`) The `options` argument to `DT::datatable`. By default

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -148,7 +148,11 @@ srv_page_data_table <- function(id,
     if_filtered <- reactive(as.logical(input$if_filtered))
     if_distinct <- reactive(as.logical(input$if_distinct))
 
-    datanames <- teal.data::datanames(isolate(data()))
+    datanames <- isolate(teal.data::datanames(data()))
+    datanames <- Filter(function(name) {
+      is.data.frame(isolate(data())[[name]])
+    }, datanames)
+
     if (!identical(datasets_selected, character(0))) {
       checkmate::assert_subset(datasets_selected, datanames)
       datanames <- datasets_selected

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -121,6 +121,9 @@ srv_page_missing_data <- function(id, data, reporter, filter_panel_api, parent_d
                                   plot_height, plot_width, ggplot2_args, ggtheme) {
   moduleServer(id, function(input, output, session) {
     datanames <- isolate(teal.data::datanames(data()))
+    datanames <- Filter(function(name) {
+      is.data.frame(isolate(data())[[name]])
+    }, datanames)
     if_subject_plot <- length(parent_dataname) > 0 && parent_dataname %in% datanames
     ns <- session$ns
 

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -1,6 +1,7 @@
 #' Missing data module
 #'
 #' Present analysis of missing observations and patients.
+#' specifically designed for use with `data.frames`.
 #'
 #' @inheritParams teal::module
 #' @inheritParams shared_params

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -2,6 +2,7 @@
 #'
 #' The variable browser provides a table with variable names and labels and a
 #' plot that visualizes the content of a particular variable.
+#' specifically designed for use with `data.frames`.
 #'
 #' @details Numeric columns with fewer than 30 distinct values can be treated as either factors
 #' or numbers with a checkbox allowing users to switch how they are treated (if < 6 unique values
@@ -17,6 +18,7 @@
 #' @param datasets_selected (`character`) A vector of datasets which should be
 #'   shown and in what order. Names in the vector have to correspond with datasets names.
 #'   If vector of length zero (default) then all datasets are shown.
+#'   Note: Only datasets of the `data.frame` class are compatible; using other types will cause an error.
 #'
 #' @aliases
 #'   tm_variable_browser_ui,
@@ -191,7 +193,8 @@ srv_variable_browser <- function(id,
 
     checkmate::assert_character(datasets_selected)
     checkmate::assert_subset(datasets_selected, datanames)
-    if (length(datasets_selected) != 0L) {
+    if (!identical(datasets_selected, character(0))) {
+      checkmate::assert_subset(datasets_selected, datanames)
       datanames <- datasets_selected
     }
 

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -185,6 +185,9 @@ srv_variable_browser <- function(id,
     .unique_records_default_as_factor <- 6 # nolint
 
     datanames <- isolate(teal.data::datanames(data()))
+    datanames <- Filter(function(name) {
+      is.data.frame(isolate(data())[[name]])
+    }, datanames)
 
     checkmate::assert_character(datasets_selected)
     checkmate::assert_subset(datasets_selected, datanames)

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -27,7 +27,9 @@ dataset will initially be shown.}
 
 \item{datasets_selected}{(\code{character}) A vector of datasets which should be
 shown and in what order. Names in the vector have to correspond with datasets names.
-If vector of length zero (default) then all datasets are shown.}
+If vector of length zero (default) then all datasets are shown.
+Note: Only datasets of the \code{data.frame} class are compatible;
+using other types will cause an error.}
 
 \item{dt_args}{(named \code{list}) Additional arguments to be passed to \code{DT::datatable}
 (must not include \code{data} or \code{options}).}
@@ -46,6 +48,7 @@ into context. For example the \code{\link[shiny:helpText]{shiny::helpText()}} el
 }
 \description{
 A data table viewer shows the data using a paginated table.
+specifically designed for use with \code{data.frames}.
 }
 \details{
 The \code{DT} package has an option \code{DT.TOJSON_ARGS} to show \code{Inf} and \code{NA} in data tables. If this is something

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -51,6 +51,7 @@ into context. For example the \code{\link[shiny:helpText]{shiny::helpText()}} el
 }
 \description{
 Present analysis of missing observations and patients.
+specifically designed for use with \code{data.frames}.
 }
 \examples{
 

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -25,7 +25,8 @@ tm_variable_browser(
 
 \item{datasets_selected}{(\code{character}) A vector of datasets which should be
 shown and in what order. Names in the vector have to correspond with datasets names.
-If vector of length zero (default) then all datasets are shown.}
+If vector of length zero (default) then all datasets are shown.
+Note: Only datasets of the \code{data.frame} class are compatible; using other types will cause an error.}
 
 \item{parent_dataname}{(\code{character(1)}) If this \code{dataname} exists in \code{datasets_selected}
 then an extra checkbox will be shown to allow users to not show variables in other datasets
@@ -48,6 +49,7 @@ For more details see the vignette: \code{vignette("custom-ggplot2-arguments", pa
 \description{
 The variable browser provides a table with variable names and labels and a
 plot that visualizes the content of a particular variable.
+specifically designed for use with \code{data.frames}.
 }
 \details{
 Numeric columns with fewer than 30 distinct values can be treated as either factors


### PR DESCRIPTION
this fixes https://github.com/insightsengineering/teal.modules.general/issues/619

Here, I am filtering `datanames `to only allow` data.frame` class and skipping other classes. Should we notify the user about datanames which are skipped ?

