### PR TITLE
Adds common `@return` for modules and corrects linting

### DIFF
--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -954,38 +954,67 @@ coloring_ggplot_call <- function(colour,
                                  fill,
                                  size,
                                  is_point = FALSE) {
-  if (!identical(colour, character(0)) && !identical(fill, character(0)) &&
-    is_point && !identical(size, character(0))) {
+  if (
+    !identical(colour, character(0)) &&
+      !identical(fill, character(0)) &&
+      is_point &&
+      !identical(size, character(0))
+  ) {
     substitute(
       expr = aes(colour = colour_name, fill = fill_name, size = size_name),
       env = list(colour_name = as.name(colour), fill_name = as.name(fill), size_name = as.name(size))
     )
-  } else if (identical(colour, character(0)) && !identical(fill, character(0)) &&
-    is_point && identical(size, character(0))) {
+  } else if (
+    identical(colour, character(0)) &&
+      !identical(fill, character(0)) &&
+      is_point &&
+      identical(size, character(0))
+  ) {
     substitute(expr = aes(fill = fill_name), env = list(fill_name = as.name(fill)))
-  } else if (!identical(colour, character(0)) && !identical(fill, character(0)) &&
-    (!is_point || identical(size, character(0)))) {
+  } else if (
+    !identical(colour, character(0)) &&
+      !identical(fill, character(0)) &&
+      (!is_point || identical(size, character(0)))
+  ) {
     substitute(
       expr = aes(colour = colour_name, fill = fill_name),
       env = list(colour_name = as.name(colour), fill_name = as.name(fill))
     )
-  } else if (!identical(colour, character(0)) && identical(fill, character(0)) &&
-    (!is_point || identical(size, character(0)))) {
+  } else if (
+    !identical(colour, character(0)) &&
+      identical(fill, character(0)) &&
+      (!is_point || identical(size, character(0)))
+  ) {
     substitute(expr = aes(colour = colour_name), env = list(colour_name = as.name(colour)))
-  } else if (identical(colour, character(0)) && !identical(fill, character(0)) &&
-    (!is_point || identical(size, character(0)))) {
+  } else if (
+    identical(colour, character(0)) &&
+      !identical(fill, character(0)) &&
+      (!is_point || identical(size, character(0)))
+  ) {
     substitute(expr = aes(fill = fill_name), env = list(fill_name = as.name(fill)))
-  } else if (identical(colour, character(0)) && identical(fill, character(0)) &&
-    is_point && !identical(size, character(0))) {
+  } else if (
+    identical(colour, character(0)) &&
+      identical(fill, character(0)) &&
+      is_point &&
+      !identical(size, character(0))
+  ) {
     substitute(expr = aes(size = size_name), env = list(size_name = as.name(size)))
-  } else if (!identical(colour, character(0)) && identical(fill, character(0)) &&
-    is_point && !identical(size, character(0))) {
+  } else if (
+    !identical(colour, character(0)) &&
+      identical(fill, character(0)) &&
+      is_point &&
+      !identical(size, character(0))
+  ) {
     substitute(
       expr = aes(colour = colour_name, size = size_name),
       env = list(colour_name = as.name(colour), size_name = as.name(size))
     )
-  } else if (identical(colour, character(0)) && !identical(fill, character(0)) &&
-    is_point && !identical(size, character(0))) {
+  } else if (
+    identical(colour, character(0)) &&
+      !identical(fill, character(0)) &&
+      is_point &&
+      !identical(size, character(0))
+  ) {
     substitute(
       expr = aes(colour = colour_name, fill = fill_name, size = size_name),
       env = list(colour_name = as.name(fill), fill_name = as.name(fill), size_name = as.name(size))

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -802,8 +802,13 @@ srv_distribution <- function(id,
           )
         }
 
-        if (length(s_var) == 0 && length(g_var) == 0 && main_type_var == "Density" &&
-          length(t_dist) != 0 && main_type_var == "Density") {
+        if (
+          length(s_var) == 0 &&
+            length(g_var) == 0 &&
+            main_type_var == "Density" &&
+            length(t_dist) != 0 &&
+            main_type_var == "Density"
+        ) {
           map_dist <- stats::setNames(
             c("dnorm", "dlnorm", "dgamma", "dunif"),
             c("normal", "lognormal", "gamma", "unif")

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -368,9 +368,8 @@ srv_g_response <- function(id,
       # nolint end
 
       plot_call <- substitute(
-        expr =
-          ggplot(ANL2, aes(x = x_cl, y = ns)) +
-            geom_bar(aes(fill = resp_cl), stat = "identity", position = arg_position),
+        expr = ggplot(ANL2, aes(x = x_cl, y = ns)) +
+          geom_bar(aes(fill = resp_cl), stat = "identity", position = arg_position),
         env = list(
           x_cl = x_cl,
           resp_cl = resp_cl,

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -459,9 +459,13 @@ srv_g_scatterplot <- function(id,
       teal.transform::compose_and_enable_validators(iv, selector_list)
     })
     iv_facet <- shinyvalidate::InputValidator$new()
-    iv_facet$add_rule("add_density", ~ if (isTRUE(.) &&
-      (length(selector_list()$row_facet()$select) > 0L ||
-        length(selector_list()$col_facet()$select) > 0L)) {
+    iv_facet$add_rule("add_density", ~ if (
+      isTRUE(.) &&
+        (
+          length(selector_list()$row_facet()$select) > 0L ||
+            length(selector_list()$col_facet()$select) > 0L
+        )
+    ) {
       "Cannot add marginal density when Row or Column facetting has been selected"
     })
     iv_facet$enable()
@@ -524,8 +528,10 @@ srv_g_scatterplot <- function(id,
     observeEvent(
       eventExpr = merged$anl_input_r()$columns_source[c("col_facet", "row_facet")],
       handlerExpr = {
-        if (length(merged$anl_input_r()$columns_source$col_facet) == 0 &&
-          length(merged$anl_input_r()$columns_source$row_facet) == 0) {
+        if (
+          length(merged$anl_input_r()$columns_source$col_facet) == 0 &&
+            length(merged$anl_input_r()$columns_source$row_facet) == 0
+        ) {
           shinyjs::hide("free_scales")
         } else {
           shinyjs::show("free_scales")
@@ -582,9 +588,11 @@ srv_g_scatterplot <- function(id,
         \n Uncheck the 'Add marginal density' checkbox to display the plot."
         ))
         validate(need(
-          !(inherits(ANL[[color_by_var]], "Date") ||
-            inherits(ANL[[color_by_var]], "POSIXct") ||
-            inherits(ANL[[color_by_var]], "POSIXlt")),
+          !(
+            inherits(ANL[[color_by_var]], "Date") ||
+              inherits(ANL[[color_by_var]], "POSIXct") ||
+              inherits(ANL[[color_by_var]], "POSIXlt")
+          ),
           "Marginal plots cannot be produced when the points are colored by Date or POSIX variables.
         \n Uncheck the 'Add marginal density' checkbox to display the plot."
         ))

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -554,9 +554,11 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
       # display those previously selected values that are still available
       selected <- if (!is.null(prev_choices) && any(prev_choices %in% choices)) {
         prev_choices[match(choices[choices %in% prev_choices], prev_choices)]
-      } else if (!is.null(prev_choices) &&
-        !any(prev_choices %in% choices) &&
-        isolate(prev_group_by_var()) == input$group_by_var) {
+      } else if (
+        !is.null(prev_choices) &&
+          !any(prev_choices %in% choices) &&
+          isolate(prev_group_by_var()) == input$group_by_var
+      ) {
         # if not any previously selected value is available and the grouping variable is the same,
         # then display NULL
         NULL

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -417,8 +417,10 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
                 expr = dplyr::mutate(is_outlier_selected = {
                   q1_q3 <- stats::quantile(outlier_var_name, probs = c(0.25, 0.75))
                   iqr <- q1_q3[2] - q1_q3[1]
-                  !(outlier_var_name >= q1_q3[1] - outlier_definition_param * iqr &
-                    outlier_var_name <= q1_q3[2] + outlier_definition_param * iqr)
+                  !(
+                    outlier_var_name >= q1_q3[1] - outlier_definition_param * iqr &
+                      outlier_var_name <= q1_q3[2] + outlier_definition_param * iqr
+                  )
                 }),
                 env = list(
                   outlier_var_name = as.name(outlier_var),

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -283,7 +283,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
           substitute(
             expr = {
               lyt <- basic_tables %>%
-              split_call %>% # styler: off
+                split_call %>% # styler: off
                 rtables::add_colcounts() %>%
                 tern::analyze_vars(
                   vars = x_name,

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,8 @@
 #' @param post_output (`shiny.tag`, optional) with text placed after the output to put the output
 #' into context. For example the [shiny::helpText()] elements are useful.
 #'
+#' @return Object of class `teal_module` to be used in `teal` applications
+#'
 #' @name shared_params
 #' @keywords internal
 NULL

--- a/man/shared_params.Rd
+++ b/man/shared_params.Rd
@@ -33,6 +33,9 @@ with text placed before the output to put the output into context. For example a
 \item{post_output}{(\code{shiny.tag}, optional) with text placed after the output to put the output
 into context. For example the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 }
+\value{
+Object of class \code{teal_module} to be used in \code{teal} applications
+}
 \description{
 Contains arguments that are shared between multiple functions
 in the package to avoid repetition using \code{inheritParams}.


### PR DESCRIPTION
Part of #624

From this https://github.com/insightsengineering/teal.modules.general/issues/624#issuecomment-1957830948

#### Changes description

- Adds `@return` tag to `shared_params` to be reused across all documentation
- Corrects linter errors