### PR TITLE
pre-release: Update verdpecheck and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,17 +18,17 @@ repos:
           - ggmosaic
           - ggplot2
           - shiny
-          - shinyTree
           - insightsengineering/teal
+          - insightsengineering/teal.transform
           - checkmate
           - dplyr
           - DT
           - forcats
           - grid
           - logger
-          - magrittr
           - scales
           - shinyjs
+          - shinyTree
           - shinyvalidate
           - shinyWidgets
           - stats
@@ -38,7 +38,6 @@ repos:
           - insightsengineering/teal.logger
           - insightsengineering/teal.reporter
           - insightsengineering/teal.slice
-          - insightsengineering/teal.transform
           - insightsengineering/teal.widgets
           - tern
           - tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,19 +74,20 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/verdepcheck: haleyjeppson/ggmosaic, tidyverse/ggplot2,
-    rstudio/shiny, shinyTree/shinyTree, insightsengineering/teal,
+    rstudio/shiny, insightsengineering/teal, insightsengineering/teal.transform,
     mllg/checkmate, tidyverse/dplyr, rstudio/DT, tidyverse/forcats,
-    daroczig/logger, tidyverse/magrittr, r-lib/scales, daattali/shinyjs,
+    daroczig/logger, r-lib/scales, daattali/shinyjs,
+    shinyTree/shinyTree,
     rstudio/shinyvalidate, dreamRs/shinyWidgets, tidyverse/stringr,
-    insightsengineering/teal.code, insightsengineering/teal.logger,
-    insightsengineering/teal.reporter, insightsengineering/teal.transform,
+    insightsengineering/teal.code, insightsengineering/teal.data,
+    insightsengineering/teal.logger, insightsengineering/teal.reporter,
     insightsengineering/teal.widgets, insightsengineering/tern,
     tidyverse/tibble, tidyverse/tidyr, tidymodels/broom,
     daattali/colourpicker, daattali/ggExtra, aphalo/ggpmisc, aphalo/ggpp,
     baddstats/goftest, gridExtra, ramnathv/htmlwidgets, jeroen/jsonlite,
     yihui/knitr, deepayan/lattice, MASS, insightsengineering/nestcolor,
-    r-lib/rlang, insightsengineering/rtables, sparkline,
-    insightsengineering/teal.data, r-lib/testthat
+    r-lib/rlang, insightsengineering/rtables, htmlwidgets/sparkline,
+    r-lib/testthat
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
# Pull Request

Part of #624

Follow-up to:

- #643

### Changes description

- Removes `magrittr` from `Config/Needs/verdepcheck`
- Re-order `verdpecheck` with same order on `Depends`, `Imports`, `Suggests`
- Re-order `pre-commit` config with same order on `Depends`, `Imports`, `Suggests`
- Add remote repo to `htmlwidgets/sparkline` (despite not being updated in years) in `verdepcheck`