### PR TITLE
Standardise function titles similar to what we have in tmc

### DIFF
--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -1,4 +1,4 @@
-#' Principal component analysis module
+#' teal Module: Principal Component Analysis
 #'
 #' Module conducts principal component analysis (PCA) on a given dataset and offers different
 #' ways of visualizing the outcomes, including elbow plot, circle plot, biplot, and eigenvector plot.
@@ -9,12 +9,6 @@
 #' @inheritParams shared_params
 #' @param dat (`data_extract_spec` or `list` of multiple `data_extract_spec`)
 #'   specifying columns used to compute PCA.
-#' @param alpha (`numeric`, optional) Specifies point opacity.
-#' - If vector of `length == 1` then the plot points will have a fixed opacity.
-#' - while vector of `value`, `min`, and `max` allows dynamic adjustment.
-#' @param size (`numeric`, optional) Specifies point size.
-#' - If vector of `length == 1` then the plot point sizes will have a fixed size
-#' - while vector of `value`, `min`, and `max` allows dynamic adjustment.
 #' @param font_size (`numeric`, optional) Specifies font size.
 #' It controls the font size for plot titles, axis labels, and legends.
 #' - If vector of `length == 1` then the font sizes will have a fixed size.

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -1,4 +1,4 @@
-#' teal Module: Principal Component Analysis
+#' `teal` module: Principal component analysis
 #'
 #' Module conducts principal component analysis (PCA) on a given dataset and offers different
 #' ways of visualizing the outcomes, including elbow plot, circle plot, biplot, and eigenvector plot.

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -1,4 +1,4 @@
-#' teal Module: Scatterplot and Regression Plot
+#' `teal` module: Scatterplot and regression analysis
 #'
 #' Module for visualizing regression analysis, including scatterplots and
 #' various regression diagnostics plots.

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -1,4 +1,4 @@
-#' Scatterplot and regression model
+#' teal Module: Scatterplot and Regression Plot
 #'
 #' Module for visualizing regression analysis, including scatterplots and
 #' various regression diagnostics plots.
@@ -14,14 +14,6 @@
 #' Regressor variables from an incoming dataset with filtering and selecting.
 #' @param response (`data_extract_spec` or `list` of multiple `data_extract_spec`)
 #' Response variables from an incoming dataset with filtering and selecting.
-#' @param alpha (`integer(1)` or `integer(3)`, optional) Specifies point opacity.
-#' - When the length of `alpha` is one: the plot points will have a fixed opacity.
-#' - When the length of `alpha` is three: the plot points opacity are dynamically adjusted based on
-#' vector of `value`, `min`, and `max`.
-#' @param size (`integer(1)` or `integer(3)`, optional) Specifies point size.
-#' - When the length of `size` is one: the plot point sizes will have a fixed size.
-#' - When the length of `size` is three: the plot points size are dynamically adjusted based on
-#' vector of `value`, `min`, and `max`.
 #' @param default_outlier_label (`character`, optional) The default column selected to label outliers.
 #' @param default_plot_type (`numeric`, optional) Defaults to Response vs Regressor.
 #' 1. Response vs Regressor

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -1,4 +1,4 @@
-#' teal Module: Data Table Viewer
+#' `teal` module: Data table viewer
 #'
 #' Module provides a dynamic and interactive way to view `data.frame`s in a `teal` application.
 #' It uses the `DT` package to display data tables in a paginated, searchable, and sortable format,

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -1,4 +1,4 @@
-#' Data table viewer module
+#' teal Module: Data Table Viewer
 #'
 #' Module provides a dynamic and interactive way to view `data.frame`s in a `teal` application.
 #' It uses the `DT` package to display data tables in a paginated, searchable, and sortable format,

--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -1,4 +1,4 @@
-#' File viewer module
+#' teal Module: File Viewer
 #'
 #' The file viewer module provides a tool to view static files.
 #' Supported formats include text formats, `PDF`, `PNG` `APNG`,

--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -1,4 +1,4 @@
-#' teal Module: File Viewer
+#' `teal` module: File viewer
 #'
 #' The file viewer module provides a tool to view static files.
 #' Supported formats include text formats, `PDF`, `PNG` `APNG`,

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -1,4 +1,4 @@
-#' Front page module
+#' teal Module: Front Page
 #'
 #' Creates a simple front page for `teal` applications, displaying
 #' introductory text, tables, additional `html` or `shiny` tags, and footnotes.

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -1,4 +1,4 @@
-#' teal Module: Front Page
+#' `teal` module: Front page
 #'
 #' Creates a simple front page for `teal` applications, displaying
 #' introductory text, tables, additional `html` or `shiny` tags, and footnotes.

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -1,4 +1,4 @@
-#' teal Module: Stack Plot with Association
+#' `teal` module: Stack plots of variables and show association with reference variable
 #'
 #' Module provides functionality for visualizing the distribution of variables and
 #' their association with a reference variable.

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -1,4 +1,4 @@
-#' Stack plots of variables and show association with reference variable
+#' teal Module: Stack Plot with Association
 #'
 #' Module provides functionality for visualizing the distribution of variables and
 #' their association with a reference variable.

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -1,4 +1,4 @@
-#' Univariate and bivariate visualizations module
+#' teal Module: Univariate and Bivariate Visualizations
 #'
 #' Module enables the creation of univariate and bivariate plots,
 #' facilitating the exploration of data distributions and relationships between two variables.

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -1,4 +1,4 @@
-#' teal Module: Univariate and Bivariate Visualizations
+#' `teal` module: Univariate and bivariate visualizations
 #'
 #' Module enables the creation of univariate and bivariate plots,
 #' facilitating the exploration of data distributions and relationships between two variables.

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -1,4 +1,4 @@
-#' Distribution analysis module
+#' teal Module: Distribution Analysis
 #'
 #' Module is designed to explore the distribution of a single variable within a given dataset.
 #' It offers several tools, such as histograms, Q-Q plots, and various statistical tests to

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -1,4 +1,4 @@
-#' teal Module: Distribution Analysis
+#' `teal` module: Distribution analysis
 #'
 #' Module is designed to explore the distribution of a single variable within a given dataset.
 #' It offers several tools, such as histograms, Q-Q plots, and various statistical tests to

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -1,4 +1,4 @@
-#' teal Module: Response Plot
+#' `teal` module: Response plot
 #'
 #' Generates a response plot for a given `response` and `x` variables.
 #' This module allows users customize and add annotations to the plot depending

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -1,4 +1,4 @@
-#' Response plot module
+#' teal Module: Response Plot
 #'
 #' Generates a response plot for a given `response` and `x` variables.
 #' This module allows users customize and add annotations to the plot depending

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -1,4 +1,4 @@
-#' teal Module: Scatterplot
+#' `teal` module: Scatterplot
 #'
 #' Generates a customizable scatterplot using `ggplot2`.
 #' This module allows users to select variables for the x and y axes,

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -1,4 +1,4 @@
-#' Scatterplot module
+#' teal Module: Scatterplot
 #'
 #' Generates a customizable scatterplot using `ggplot2`.
 #' This module allows users to select variables for the x and y axes,
@@ -22,12 +22,6 @@
 #' Specifies the variable(s) for faceting rows.
 #' @param col_facet (`data_extract_spec` or `list` of multiple `data_extract_spec`, optional)
 #' Specifies the variable(s) for faceting columns.
-#' @param alpha (`numeric`, optional) Specifies point opacity.
-#' - If vector of `length == 1` then the plot points will have a fixed opacity.
-#' - while vector of `value`, `min`, and `max` allows dynamic adjustment.
-#' @param size (`numeric`, optional) Specifies point size.
-#' - If vector of `length == 1` then the plot point sizes will have a fixed size
-#' - while vector of `value`, `min`, and `max` allows dynamic adjustment.
 #' @param shape (`character`, optional) A character vector with the names of the
 #' shape, e.g. `c("triangle", "square", "circle")`. It defaults to `shape_names`. This is a complete list from
 #' `vignette("ggplot2-specs", package="ggplot2")`.

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -1,4 +1,4 @@
-#' Scatterplot matrix module
+#' teal Module: Scatterplot Matrix
 #'
 #' Generates a scatterplot matrix from selected `variables` from datasets.
 #' Each plot within the matrix represents the relationship between two variables,

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -1,4 +1,4 @@
-#' teal Module: Scatterplot Matrix
+#' `teal` module: Scatterplot matrix
 #'
 #' Generates a scatterplot matrix from selected `variables` from datasets.
 #' Each plot within the matrix represents the relationship between two variables,

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -1,4 +1,4 @@
-#' teal Module: Missing Data Analysis
+#' `teal` module: Missing data analysis
 #'
 #' Module analyzes missing data in `data.frame`s to help users explore missing observations and
 #' gain insights into the completeness of their data.

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -1,4 +1,4 @@
-#' Missing data analysis module
+#' teal Module: Missing Data Analysis
 #'
 #' Module analyzes missing data in `data.frame`s to help users explore missing observations and
 #' gain insights into the completeness of their data.

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -1,4 +1,4 @@
-#' Outliers module
+#' teal Module: Outliers Analysis
 #'
 #' Module to analyze and identify outliers using different methods
 #' such as IQR, Z-score, and Percentiles, and offers visualizations including

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -1,4 +1,4 @@
-#' teal Module: Outliers Analysis
+#' `teal` module: Outliers analysis
 #'
 #' Module to analyze and identify outliers using different methods
 #' such as IQR, Z-score, and Percentiles, and offers visualizations including

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -1,4 +1,4 @@
-#' teal Module: Cross-Table
+#' `teal` module: Cross-table
 #'
 #' Generates a simple cross-table of two variables from a dataset with custom
 #' options for showing percentages and sub-totals.

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -1,4 +1,4 @@
-#' Cross-table module
+#' teal Module: Cross-Table
 #'
 #' Generates a simple cross-table of two variables from a dataset with custom
 #' options for showing percentages and sub-totals.

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -1,4 +1,4 @@
-#' teal Module: Variable Browser
+#' `teal` module: Variable browser
 #'
 #' Module provides provides a detailed summary and visualization of variable distributions
 #' for `data.frame` objects, with interactive features to customize analysis.

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -1,4 +1,4 @@
-#' Variable browser `teal` module
+#' teal Module: Variable Browser
 #'
 #' Module provides provides a detailed summary and visualization of variable distributions
 #' for `data.frame` objects, with interactive features to customize analysis.

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,6 +26,15 @@
 #' @param post_output (`shiny.tag`, optional) Text or UI element to be displayed after the module's output,
 #' adding context or further instructions. Elements like `shiny::helpText()` are useful.
 #'
+#' @param alpha (`integer(1)` or `integer(3)`, optional) Specifies point opacity.
+#' - When the length of `alpha` is one: the plot points will have a fixed opacity.
+#' - When the length of `alpha` is three: the plot points opacity are dynamically adjusted based on
+#' vector of `value`, `min`, and `max`.
+#' @param size (`integer(1)` or `integer(3)`, optional) Specifies point size.
+#' - When the length of `size` is one: the plot point sizes will have a fixed size.
+#' - When the length of `size` is three: the plot points size are dynamically adjusted based on
+#' vector of `value`, `min`, and `max`.
+#'
 #' @return Object of class `teal_module` to be used in `teal` applications.
 #'
 #' @name shared_params

--- a/man/shared_params.Rd
+++ b/man/shared_params.Rd
@@ -33,6 +33,20 @@ with text placed before the output to put the output into context. For example a
 
 \item{post_output}{(\code{shiny.tag}, optional) Text or UI element to be displayed after the module's output,
 adding context or further instructions. Elements like \code{shiny::helpText()} are useful.}
+
+\item{alpha}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point opacity.
+\itemize{
+\item When the length of \code{alpha} is one: the plot points will have a fixed opacity.
+\item When the length of \code{alpha} is three: the plot points opacity are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
+}}
+
+\item{size}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point size.
+\itemize{
+\item When the length of \code{size} is one: the plot point sizes will have a fixed size.
+\item When the length of \code{size} is three: the plot points size are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
+}}
 }
 \value{
 Object of class \code{teal_module} to be used in \code{teal} applications.

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_a_pca.R
 \name{tm_a_pca}
 \alias{tm_a_pca}
-\title{Principal component analysis module}
+\title{teal Module: Principal Component Analysis}
 \usage{
 tm_a_pca(
   label = "Principal Component Analysis",
@@ -52,16 +52,18 @@ It controls the font size for plot titles, axis labels, and legends.
 \item while vector of \code{value}, \code{min}, and \code{max} allows dynamic adjustment.
 }}
 
-\item{alpha}{(\code{numeric}, optional) Specifies point opacity.
+\item{alpha}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point opacity.
 \itemize{
-\item If vector of \code{length == 1} then the plot points will have a fixed opacity.
-\item while vector of \code{value}, \code{min}, and \code{max} allows dynamic adjustment.
+\item When the length of \code{alpha} is one: the plot points will have a fixed opacity.
+\item When the length of \code{alpha} is three: the plot points opacity are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
 }}
 
-\item{size}{(\code{numeric}, optional) Specifies point size.
+\item{size}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point size.
 \itemize{
-\item If vector of \code{length == 1} then the plot point sizes will have a fixed size
-\item while vector of \code{value}, \code{min}, and \code{max} allows dynamic adjustment.
+\item When the length of \code{size} is one: the plot point sizes will have a fixed size.
+\item When the length of \code{size} is three: the plot points size are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
 }}
 
 \item{pre_output}{(\code{shiny.tag}, optional) Text or UI element to be displayed before the module's output,

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_a_pca.R
 \name{tm_a_pca}
 \alias{tm_a_pca}
-\title{teal Module: Principal Component Analysis}
+\title{\code{teal} module: Principal component analysis}
 \usage{
 tm_a_pca(
   label = "Principal Component Analysis",

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_a_regression.R
 \name{tm_a_regression}
 \alias{tm_a_regression}
-\title{teal Module: Scatterplot and Regression Plot}
+\title{\code{teal} module: Scatterplot and regression analysis}
 \usage{
 tm_a_regression(
   label = "Regression Analysis",

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_a_regression.R
 \name{tm_a_regression}
 \alias{tm_a_regression}
-\title{Scatterplot and regression model}
+\title{teal Module: Scatterplot and Regression Plot}
 \usage{
 tm_a_regression(
   label = "Regression Analysis",

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_data_table.R
 \name{tm_data_table}
 \alias{tm_data_table}
-\title{teal Module: Data Table Viewer}
+\title{\code{teal} module: Data table viewer}
 \usage{
 tm_data_table(
   label = "Data Table",

--- a/man/tm_data_table.Rd
+++ b/man/tm_data_table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_data_table.R
 \name{tm_data_table}
 \alias{tm_data_table}
-\title{Data table viewer module}
+\title{teal Module: Data Table Viewer}
 \usage{
 tm_data_table(
   label = "Data Table",

--- a/man/tm_file_viewer.Rd
+++ b/man/tm_file_viewer.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_file_viewer.R
 \name{tm_file_viewer}
 \alias{tm_file_viewer}
-\title{teal Module: File Viewer}
+\title{\code{teal} module: File viewer}
 \usage{
 tm_file_viewer(
   label = "File Viewer Module",

--- a/man/tm_file_viewer.Rd
+++ b/man/tm_file_viewer.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_file_viewer.R
 \name{tm_file_viewer}
 \alias{tm_file_viewer}
-\title{File viewer module}
+\title{teal Module: File Viewer}
 \usage{
 tm_file_viewer(
   label = "File Viewer Module",

--- a/man/tm_front_page.Rd
+++ b/man/tm_front_page.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_front_page.R
 \name{tm_front_page}
 \alias{tm_front_page}
-\title{Front page module}
+\title{teal Module: Front Page}
 \usage{
 tm_front_page(
   label = "Front page",

--- a/man/tm_front_page.Rd
+++ b/man/tm_front_page.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_front_page.R
 \name{tm_front_page}
 \alias{tm_front_page}
-\title{teal Module: Front Page}
+\title{\code{teal} module: Front page}
 \usage{
 tm_front_page(
   label = "Front page",

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_association.R
 \name{tm_g_association}
 \alias{tm_g_association}
-\title{Stack plots of variables and show association with reference variable}
+\title{teal Module: Stack Plot with Association}
 \usage{
 tm_g_association(
   label = "Association",

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_association.R
 \name{tm_g_association}
 \alias{tm_g_association}
-\title{teal Module: Stack Plot with Association}
+\title{\code{teal} module: Stack plots of variables and show association with reference variable}
 \usage{
 tm_g_association(
   label = "Association",

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_bivariate.R
 \name{tm_g_bivariate}
 \alias{tm_g_bivariate}
-\title{teal Module: Univariate and Bivariate Visualizations}
+\title{\code{teal} module: Univariate and bivariate visualizations}
 \usage{
 tm_g_bivariate(
   label = "Bivariate Plots",

--- a/man/tm_g_bivariate.Rd
+++ b/man/tm_g_bivariate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_bivariate.R
 \name{tm_g_bivariate}
 \alias{tm_g_bivariate}
-\title{Univariate and bivariate visualizations module}
+\title{teal Module: Univariate and Bivariate Visualizations}
 \usage{
 tm_g_bivariate(
   label = "Bivariate Plots",

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_distribution.R
 \name{tm_g_distribution}
 \alias{tm_g_distribution}
-\title{Distribution analysis module}
+\title{teal Module: Distribution Analysis}
 \usage{
 tm_g_distribution(
   label = "Distribution Module",

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_distribution.R
 \name{tm_g_distribution}
 \alias{tm_g_distribution}
-\title{teal Module: Distribution Analysis}
+\title{\code{teal} module: Distribution analysis}
 \usage{
 tm_g_distribution(
   label = "Distribution Module",

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_response.R
 \name{tm_g_response}
 \alias{tm_g_response}
-\title{Response plot module}
+\title{teal Module: Response Plot}
 \usage{
 tm_g_response(
   label = "Response Plot",

--- a/man/tm_g_response.Rd
+++ b/man/tm_g_response.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_response.R
 \name{tm_g_response}
 \alias{tm_g_response}
-\title{teal Module: Response Plot}
+\title{\code{teal} module: Response plot}
 \usage{
 tm_g_response(
   label = "Response Plot",

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_scatterplot.R
 \name{tm_g_scatterplot}
 \alias{tm_g_scatterplot}
-\title{Scatterplot module}
+\title{teal Module: Scatterplot}
 \usage{
 tm_g_scatterplot(
   label = "Scatterplot",
@@ -54,20 +54,22 @@ Specifies the variable(s) for faceting columns.}
 \item{plot_width}{optional, (\code{numeric}) Specifies the plot width as a three-element vector of
 \code{value}, \code{min}, and \code{max} for a slider encoding the plot width.}
 
-\item{alpha}{(\code{numeric}, optional) Specifies point opacity.
+\item{alpha}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point opacity.
 \itemize{
-\item If vector of \code{length == 1} then the plot points will have a fixed opacity.
-\item while vector of \code{value}, \code{min}, and \code{max} allows dynamic adjustment.
+\item When the length of \code{alpha} is one: the plot points will have a fixed opacity.
+\item When the length of \code{alpha} is three: the plot points opacity are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
 }}
 
 \item{shape}{(\code{character}, optional) A character vector with the names of the
 shape, e.g. \code{c("triangle", "square", "circle")}. It defaults to \code{shape_names}. This is a complete list from
 \code{vignette("ggplot2-specs", package="ggplot2")}.}
 
-\item{size}{(\code{numeric}, optional) Specifies point size.
+\item{size}{(\code{integer(1)} or \code{integer(3)}, optional) Specifies point size.
 \itemize{
-\item If vector of \code{length == 1} then the plot point sizes will have a fixed size
-\item while vector of \code{value}, \code{min}, and \code{max} allows dynamic adjustment.
+\item When the length of \code{size} is one: the plot point sizes will have a fixed size.
+\item When the length of \code{size} is three: the plot points size are dynamically adjusted based on
+vector of \code{value}, \code{min}, and \code{max}.
 }}
 
 \item{max_deg}{(\code{integer}, optional) The maximum degree for the polynomial trend line. Must not be less than 1.}

--- a/man/tm_g_scatterplot.Rd
+++ b/man/tm_g_scatterplot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_scatterplot.R
 \name{tm_g_scatterplot}
 \alias{tm_g_scatterplot}
-\title{teal Module: Scatterplot}
+\title{\code{teal} module: Scatterplot}
 \usage{
 tm_g_scatterplot(
   label = "Scatterplot",

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_scatterplotmatrix.R
 \name{tm_g_scatterplotmatrix}
 \alias{tm_g_scatterplotmatrix}
-\title{Scatterplot matrix module}
+\title{teal Module: Scatterplot Matrix}
 \usage{
 tm_g_scatterplotmatrix(
   label = "Scatterplot Matrix",

--- a/man/tm_g_scatterplotmatrix.Rd
+++ b/man/tm_g_scatterplotmatrix.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_g_scatterplotmatrix.R
 \name{tm_g_scatterplotmatrix}
 \alias{tm_g_scatterplotmatrix}
-\title{teal Module: Scatterplot Matrix}
+\title{\code{teal} module: Scatterplot matrix}
 \usage{
 tm_g_scatterplotmatrix(
   label = "Scatterplot Matrix",

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_missing_data.R
 \name{tm_missing_data}
 \alias{tm_missing_data}
-\title{teal Module: Missing Data Analysis}
+\title{\code{teal} module: Missing data analysis}
 \usage{
 tm_missing_data(
   label = "Missing data",

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_missing_data.R
 \name{tm_missing_data}
 \alias{tm_missing_data}
-\title{Missing data analysis module}
+\title{teal Module: Missing Data Analysis}
 \usage{
 tm_missing_data(
   label = "Missing data",

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_outliers.R
 \name{tm_outliers}
 \alias{tm_outliers}
-\title{teal Module: Outliers Analysis}
+\title{\code{teal} module: Outliers analysis}
 \usage{
 tm_outliers(
   label = "Outliers Module",

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_outliers.R
 \name{tm_outliers}
 \alias{tm_outliers}
-\title{Outliers module}
+\title{teal Module: Outliers Analysis}
 \usage{
 tm_outliers(
   label = "Outliers Module",

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_t_crosstable.R
 \name{tm_t_crosstable}
 \alias{tm_t_crosstable}
-\title{teal Module: Cross-Table}
+\title{\code{teal} module: Cross-table}
 \usage{
 tm_t_crosstable(
   label = "Cross Table",

--- a/man/tm_t_crosstable.Rd
+++ b/man/tm_t_crosstable.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_t_crosstable.R
 \name{tm_t_crosstable}
 \alias{tm_t_crosstable}
-\title{Cross-table module}
+\title{teal Module: Cross-Table}
 \usage{
 tm_t_crosstable(
   label = "Cross Table",

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_variable_browser.R
 \name{tm_variable_browser}
 \alias{tm_variable_browser}
-\title{Variable browser \code{teal} module}
+\title{teal Module: Variable Browser}
 \usage{
 tm_variable_browser(
   label = "Variable Browser",

--- a/man/tm_variable_browser.Rd
+++ b/man/tm_variable_browser.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tm_variable_browser.R
 \name{tm_variable_browser}
 \alias{tm_variable_browser}
-\title{teal Module: Variable Browser}
+\title{\code{teal} module: Variable browser}
 \usage{
 tm_variable_browser(
   label = "Variable Browser",


### PR DESCRIPTION
Closes #684 

Changes:

Titles now follow this format:
```
`teal` module: Function title
```

Additionally, moved the function params `alpha` and `size` to `shared_params` as they were used in 3 places.
Note that the `tm_g_bivariate()` uses `size` param with a different meaning. We might want to think about function arg standardization in the future.