### PR TITLE
Update to roxygen2 `@template` for `ggplot2_args` arguments

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,7 +28,7 @@ SECURITY.md
 ^Jenkinsfile$
 ^logs$
 ^Makefile$
-^man-roxygen$
+^man/roxygen$
 ^Meta$
 ^outputdir$
 ^scratch$

--- a/man-roxygen/ggplot2_args_multi.R
+++ b/man-roxygen/ggplot2_args_multi.R
@@ -1,7 +1,0 @@
-#' @param ggplot2_args optional, (`ggplot2_args`) object created by [`teal.widgets::ggplot2_args()`]
-#'  with settings for all the plots or named list of `ggplot2_args` objects for plot-specific settings.
-#'  The argument is merged with options variable `teal.ggplot2_args` and default module setup.
-#'
-#'  List names should match the following: `c("default", <%=ggnames%>)`.
-#'
-#'  For more details see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.widgets")`.

--- a/man/roxygen/templates/ggplot2_args_multi.R
+++ b/man/roxygen/templates/ggplot2_args_multi.R
@@ -1,0 +1,8 @@
+#' @param ggplot2_args (`ggplot2_args` or `named list` of `ggplot2_args`s) optional.
+#' Object created by [`teal.widgets::ggplot2_args()`] and contains settings for all the plots,
+#' or is a named `list` of `ggplot2_args` objects for plot-specific settings.
+#' The argument is merged with options variable `teal.ggplot2_args` and default module setup.
+#'
+#' List names should match the following: `c("default", <%=ggnames%>)`.
+#'
+#' For more details see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.widgets")`.

--- a/man/tm_a_pca.Rd
+++ b/man/tm_a_pca.Rd
@@ -34,8 +34,9 @@ specifying columns used to compute PCA.}
 
 \item{ggtheme}{optional, (\code{character}) \code{ggplot2} theme to be used by default. Defaults to \code{"gray"}.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \code{c("default", "Elbow plot", "Circle plot", "Biplot", "Eigenvector plot")}.

--- a/man/tm_a_regression.Rd
+++ b/man/tm_a_regression.Rd
@@ -52,8 +52,9 @@ vector of \code{value}, \code{min}, and \code{max}.
 
 \item{ggtheme}{optional, (\code{character}) \code{ggplot2} theme to be used by default. Defaults to \code{"gray"}.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \verb{c("default", "Response vs Regressor", "Residuals vs Fitted", "Scale-Location", "Cook's distance", "Residuals vs Leverage"", "Cook's dist vs Leverage")}.

--- a/man/tm_g_association.Rd
+++ b/man/tm_g_association.Rd
@@ -50,8 +50,9 @@ with text placed before the output to put the output into context. For example a
 \item{post_output}{(\code{shiny.tag}, optional) Text or UI element to be displayed after the module's output,
 adding context or further instructions. Elements like \code{shiny::helpText()} are useful.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \code{c("default", "Bivariate1", "Bivariate2")}.

--- a/man/tm_g_distribution.Rd
+++ b/man/tm_g_distribution.Rd
@@ -37,8 +37,9 @@ Defaults to density (\code{FALSE}).}
 
 \item{ggtheme}{optional, (\code{character}) \code{ggplot2} theme to be used by default. Defaults to \code{"gray"}.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \code{c("default", "Histogram", "QQplot")}.

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -33,8 +33,9 @@ ignored.}
 
 \item{ggtheme}{(\code{character}, optional) Specifies the default \code{ggplot2} theme for plots. Defaults to \code{classic}.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \code{c("default", "Summary Obs", "Summary Patients", "Combinations Main", "Combinations Hist", "By Subject")}.

--- a/man/tm_outliers.Rd
+++ b/man/tm_outliers.Rd
@@ -28,8 +28,9 @@ Specifies the categorical variable(s) to split the selected outlier variables on
 
 \item{ggtheme}{optional, (\code{character}) \code{ggplot2} theme to be used by default. Defaults to \code{"gray"}.}
 
-\item{ggplot2_args}{optional, (\code{ggplot2_args}) object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}}
-with settings for all the plots or named list of \code{ggplot2_args} objects for plot-specific settings.
+\item{ggplot2_args}{(\code{ggplot2_args} or \verb{named list} of \code{ggplot2_args}s) optional.
+Object created by \code{\link[teal.widgets:ggplot2_args]{teal.widgets::ggplot2_args()}} and contains settings for all the plots,
+or is a named \code{list} of \code{ggplot2_args} objects for plot-specific settings.
 The argument is merged with options variable \code{teal.ggplot2_args} and default module setup.
 
 List names should match the following: \code{c("default", "Boxplot","Density Plot","Cumulative Distribution Plot")}.


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Part of #624

#### Changes description

- Update type in `ggplot2_args`
- Minor change to phrasing
- Move template file under `man` page to avoid extra folder at root level ([available since](https://roxygen2.r-lib.org/news/index.html?q=template#options-7-0-0) `roxygen2@7.0.0`)
- Update `.Rbuildignore` accordingly

#### Reviewer should consider

- `@template` has been superseded (https://roxygen2.r-lib.org/articles/reuse.html?q=template#superseded)
  - There's no equivalent though _(with parameterized strings)_
  - Alternative: we could add `ggplot2_args` to `shared_params` and specific list of names it can take in `@details` on each function that uses this