### PR TITLE
Removes unnecessary `# nolint ` after `object_name_linter` was changed

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,5 +2,5 @@ linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   cyclocomp_linter = NULL,
   object_usage_linter = NULL,
-  object_name_linter = object_name_linter(styles = c("snake_case", "symbols"), regexes = c(ANL = "^ANL_?[0-9]*$", ADaM = "^r?AD[A-Z]{2,3}_?[0-9]*$"))
+  object_name_linter = object_name_linter(styles = c("snake_case", "symbols"), regexes = c(ANL = "^ANL_?[0-9A-Z_]*$", ADaM = "^r?AD[A-Z]{2,3}_?[0-9]*$"))
   )

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -391,7 +391,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       standardization <- input$standardization
       center <- standardization %in% c("center", "center_scale")
       scale <- standardization == "center_scale"
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
 
       teal::validate_has_data(ANL, 10)
       validate(need(
@@ -422,7 +422,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       standardization <- input$standardization
       center <- standardization %in% c("center", "center_scale")
       scale <- standardization == "center_scale"
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
 
       qenv <- teal.code::eval_code(
         merged$anl_q_r(),
@@ -435,7 +435,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
       if (na_action == "drop") {
         qenv <- teal.code::eval_code(
           qenv,
-          quote(ANL <- tidyr::drop_na(ANL, keep_columns)) # nolint: object_name.
+          quote(ANL <- tidyr::drop_na(ANL, keep_columns))
         )
       }
 
@@ -657,7 +657,7 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
     plot_biplot <- function(base_q) {
       qenv <- base_q
 
-      ANL <- qenv[["ANL"]] # nolint: object_name.
+      ANL <- qenv[["ANL"]]
 
       resp_col <- as.character(merged$anl_input_r()$columns_source$response)
       dat_cols <- as.character(merged$anl_input_r()$columns_source$dat)

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -436,7 +436,7 @@ srv_a_regression <- function(id,
 
     # sets qenv object and populates it with data merge call and fit expression
     fit_r <- reactive({
-      ANL <- anl_merged_q()[["ANL"]] # nolint: object_name.
+      ANL <- anl_merged_q()[["ANL"]]
       teal::validate_has_data(ANL, 10)
 
       validate(need(is.numeric(ANL[regression_var()$response][[1]]), "Response variable should be numeric."))
@@ -546,7 +546,7 @@ srv_a_regression <- function(id,
 
       plot_type_0 <- function() {
         fit <- fit_r()[["fit"]]
-        ANL <- anl_merged_q()[["ANL"]] # nolint: object_name.
+        ANL <- anl_merged_q()[["ANL"]]
 
         stopifnot(ncol(fit$model) == 2)
 

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -326,7 +326,7 @@ srv_tm_g_association <- function(id,
     output_q <- reactive({
       teal::validate_inputs(iv_r())
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       teal::validate_has_data(ANL, 3)
 
       vars_names <- merged$anl_input_r()$columns_source$vars

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -535,7 +535,7 @@ srv_g_bivariate <- function(id,
     output_q <- reactive({
       teal::validate_inputs(iv_r())
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       teal::validate_has_data(ANL, 3)
 
       x_col_vec <- as.vector(merged$anl_input_r()$columns_source$x)

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -518,7 +518,7 @@ srv_distribution <- function(id,
             )
           }
 
-          ANL <- merged$anl_q_r()[[as.character(dist_var[[1]]$dataname)]] # nolint: object_name.
+          ANL <- merged$anl_q_r()[[as.character(dist_var[[1]]$dataname)]]
           params <- get_dist_params(as.numeric(stats::na.omit(ANL[[dist_var2]])), input$t_dist)
           params_vec <- round(unname(unlist(params)), 2)
           params_names <- names(params)
@@ -558,7 +558,7 @@ srv_distribution <- function(id,
     common_q <- reactive({
       # Create a private stack for this function only.
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       dist_var <- merge_vars()$dist_var
       s_var <- merge_vars()$s_var
       g_var <- merge_vars()$g_var
@@ -585,7 +585,7 @@ srv_distribution <- function(id,
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL[[g_var]] <- forcats::fct_na_value_to_level(as.factor(ANL[[g_var]]), "NA"), # nolint: object_name.
+            expr = ANL[[g_var]] <- forcats::fct_na_value_to_level(as.factor(ANL[[g_var]]), "NA"),
             env = list(g_var = g_var)
           )
         )
@@ -601,7 +601,7 @@ srv_distribution <- function(id,
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL[[s_var]] <- forcats::fct_na_value_to_level(as.factor(ANL[[s_var]]), "NA"), # nolint: object_name.
+            expr = ANL[[s_var]] <- forcats::fct_na_value_to_level(as.factor(ANL[[s_var]]), "NA"),
             env = list(s_var = s_var)
           )
         )
@@ -1024,7 +1024,7 @@ srv_distribution <- function(id,
       },
       valueExpr = {
         # Create a private stack for this function only.
-        ANL <- common_q()[["ANL"]] # nolint: object_name.
+        ANL <- common_q()[["ANL"]]
 
         dist_var <- merge_vars()$dist_var
         s_var <- merge_vars()$s_var

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -372,7 +372,7 @@ srv_g_response <- function(id,
       teal::validate_inputs(iv_r())
 
       qenv <- merged$anl_q_r()
-      ANL <- qenv[["ANL"]] # nolint: object_name.
+      ANL <- qenv[["ANL"]]
       resp_var <- as.vector(merged$anl_input_r()$columns_source$response)
       x <- as.vector(merged$anl_input_r()$columns_source$x)
 
@@ -409,7 +409,7 @@ srv_g_response <- function(id,
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL[[x]] <- with(ANL, forcats::fct_rev(x_cl)), # nolint: object_name.
+            expr = ANL[[x]] <- with(ANL, forcats::fct_rev(x_cl)),
             env = list(x = x, x_cl = x_cl)
           )
         )
@@ -418,7 +418,7 @@ srv_g_response <- function(id,
       qenv <- teal.code::eval_code(
         qenv,
         substitute(
-          expr = ANL[[resp_var]] <- factor(ANL[[resp_var]]), # nolint: object_name.
+          expr = ANL[[resp_var]] <- factor(ANL[[resp_var]]),
           env = list(resp_var = resp_var)
         )
       ) %>%

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -568,7 +568,7 @@ srv_g_scatterplot <- function(id,
     )
 
     trend_line_is_applicable <- reactive({
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       x_var <- as.vector(merged$anl_input_r()$columns_source$x)
       y_var <- as.vector(merged$anl_input_r()$columns_source$y)
       length(x_var) > 0 && length(y_var) > 0 && is.numeric(ANL[[x_var]]) && is.numeric(ANL[[y_var]])
@@ -595,7 +595,7 @@ srv_g_scatterplot <- function(id,
 
     output$num_na_removed <- renderUI({
       if (add_trend_line()) {
-        ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+        ANL <- merged$anl_q_r()[["ANL"]]
         x_var <- as.vector(merged$anl_input_r()$columns_source$x)
         y_var <- as.vector(merged$anl_input_r()$columns_source$y)
         if ((num_total_na <- nrow(ANL) - nrow(stats::na.omit(ANL[, c(x_var, y_var)]))) > 0) {
@@ -621,7 +621,7 @@ srv_g_scatterplot <- function(id,
     output_q <- reactive({
       teal::validate_inputs(iv_r(), iv_facet)
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
 
       x_var <- as.vector(merged$anl_input_r()$columns_source$x)
       y_var <- as.vector(merged$anl_input_r()$columns_source$y)
@@ -724,7 +724,7 @@ srv_g_scatterplot <- function(id,
         plot_q <- teal.code::eval_code(
           object = plot_q,
           code = substitute(
-            expr = ANL[, log_x_var] <- log_x_fn(ANL[, x_var]), # nolint: object_name.
+            expr = ANL[, log_x_var] <- log_x_fn(ANL[, x_var]),
             env = list(
               x_var = x_var,
               log_x_fn = as.name(log_x_fn),
@@ -739,7 +739,7 @@ srv_g_scatterplot <- function(id,
         plot_q <- teal.code::eval_code(
           object = plot_q,
           code = substitute(
-            expr = ANL[, log_y_var] <- log_y_fn(ANL[, y_var]), # nolint: object_name.
+            expr = ANL[, log_y_var] <- log_y_fn(ANL[, y_var]),
             env = list(
               y_var = y_var,
               log_y_fn = as.name(log_y_fn),
@@ -872,7 +872,7 @@ srv_g_scatterplot <- function(id,
             plot_q <- teal.code::eval_code(
               plot_q,
               substitute(
-                expr = ANL <- dplyr::filter(ANL, !is.na(x_var) & !is.na(y_var)), # nolint: object_name.
+                expr = ANL <- dplyr::filter(ANL, !is.na(x_var) & !is.na(y_var)),
                 env = list(x_var = as.name(x_var), y_var = as.name(y_var))
               )
             )

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -299,7 +299,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
       teal::validate_inputs(iv_r())
 
       qenv <- merged$anl_q_r()
-      ANL <- qenv[["ANL"]] # nolint: object_name.
+      ANL <- qenv[["ANL"]]
 
       cols_names <- merged$anl_input_r()$columns_source$variables
       alpha <- input$alpha
@@ -326,7 +326,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL <- ANL[, cols_names] %>% # nolint: object_name.
+            expr = ANL <- ANL[, cols_names] %>%
               dplyr::mutate_if(is.character, as.factor) %>%
               droplevels(),
             env = list(cols_names = cols_names)
@@ -336,7 +336,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL <- ANL[, cols_names] %>% # nolint: object_name.
+            expr = ANL <- ANL[, cols_names] %>%
               droplevels(),
             env = list(cols_names = cols_names)
           )
@@ -421,7 +421,7 @@ srv_g_scatterplotmatrix <- function(id, data, reporter, filter_panel_api, variab
     output$message <- renderText({
       shiny::req(iv_r()$is_valid())
       req(selector_list()$variables())
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       cols_names <- unique(unname(do.call(c, merged$anl_input_r()$columns_source)))
       check_char <- vapply(ANL[, cols_names], is.character, logical(1))
       if (any(check_char)) {

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -478,14 +478,14 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
         teal.code::eval_code(
           data(),
           substitute(
-            expr = ANL <- anl_name[, selected_vars, drop = FALSE], # nolint: object_name.
+            expr = ANL <- anl_name[, selected_vars, drop = FALSE],
             env = list(anl_name = as.name(dataname), selected_vars = selected_vars())
           )
         )
       } else {
         teal.code::eval_code(
           data(),
-          substitute(expr = ANL <- anl_name, env = list(anl_name = as.name(dataname))) # nolint: object_name.
+          substitute(expr = ANL <- anl_name, env = list(anl_name = as.name(dataname)))
         )
       }
 
@@ -493,7 +493,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL[[group_var]] <- anl_name[[group_var]], # nolint: object_name.
+            expr = ANL[[group_var]] <- anl_name[[group_var]],
             env = list(group_var = group_var, anl_name = as.name(dataname))
           )
         )
@@ -645,7 +645,7 @@ srv_missing_data <- function(id, data, reporter, filter_panel_api, dataname, par
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
-            expr = ANL[[new_col_name]] <- ifelse(rowSums(is.na(ANL)) > 0, NA, FALSE), # nolint: object_name.
+            expr = ANL[[new_col_name]] <- ifelse(rowSums(is.na(ANL)) > 0, NA, FALSE),
             env = list(new_col_name = new_col_name)
           )
         )

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -389,7 +389,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     n_outlier_missing <- reactive({
       shiny::req(iv_r()$is_valid())
       outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       sum(is.na(ANL[[outlier_var]]))
     })
 
@@ -399,7 +399,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     common_code_q <- reactive({
       shiny::req(iv_r()$is_valid())
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
       qenv <- merged$anl_q_r()
 
       outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)
@@ -428,7 +428,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           qenv <- teal.code::eval_code(
             qenv,
             substitute(
-              expr = ANL <- ANL %>% dplyr::filter(!is.na(outlier_var_name)), # nolint: object_name.
+              expr = ANL <- ANL %>% dplyr::filter(!is.na(outlier_var_name)),
               env = list(outlier_var_name = as.name(outlier_var))
             )
           )
@@ -445,7 +445,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           qenv <- teal.code::eval_code(
             qenv,
             substitute(
-              expr = ANL <- ANL %>% dplyr::filter(!is.na(outlier_var_name)), # nolint: object_name.
+              expr = ANL <- ANL %>% dplyr::filter(!is.na(outlier_var_name)),
               env = list(outlier_var_name = as.name(outlier_var))
             )
           )
@@ -477,7 +477,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         qenv,
         substitute(
           expr = {
-            ANL_OUTLIER <- ANL %>% # nolint: object_name.
+            ANL_OUTLIER <- ANL %>%
               group_expr %>% # styler: off
               dplyr::mutate(is_outlier = {
                 q1_q3 <- stats::quantile(outlier_var_name, probs = c(0.25, 0.75))
@@ -545,7 +545,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         qenv,
         substitute(
           expr = {
-            ANL_OUTLIER_EXTENDED <- dplyr::left_join( # nolint: object_name.
+            ANL_OUTLIER_EXTENDED <- dplyr::left_join(
               ANL_OUTLIER,
               dplyr::select(
                 dataname,
@@ -624,13 +624,13 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
               # In order for geom_rug to work properly when reordering takes place inside facet_grid,
               # all tables must have the column used for reording.
               # In this case, the column used for reordering is `order`.
-              ANL_OUTLIER <- dplyr::left_join( # nolint: object_name.
+              ANL_OUTLIER <- dplyr::left_join(
                 ANL_OUTLIER,
                 summary_table_pre[, c("order", categorical_var)],
                 by = categorical_var
               )
               # so that x axis of plot aligns with columns of summary table, from most outliers to least by percentage
-              ANL <- ANL %>% # nolint: object_name.
+              ANL <- ANL %>%
                 dplyr::left_join(
                   dplyr::select(summary_table_pre, categorical_var_name, order),
                   by = categorical_var
@@ -685,8 +685,8 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     # boxplot/violinplot # nolint commented_code
     boxplot_q <- reactive({
       req(common_code_q())
-      ANL <- common_code_q()[["ANL"]] # nolint: object_name.
-      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
+      ANL <- common_code_q()[["ANL"]]
+      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
 
       outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)
       categorical_var <- as.vector(merged$anl_input_r()$columns_source$categorical_var)
@@ -777,8 +777,8 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
 
     # density plot
     density_plot_q <- reactive({
-      ANL <- common_code_q()[["ANL"]] # nolint: object_name.
-      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
+      ANL <- common_code_q()[["ANL"]]
+      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
 
       outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)
       categorical_var <- as.vector(merged$anl_input_r()$columns_source$categorical_var)
@@ -837,8 +837,8 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
 
     # Cumulative distribution plot
     cumulative_plot_q <- reactive({
-      ANL <- common_code_q()[["ANL"]] # nolint: object_name.
-      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
+      ANL <- common_code_q()[["ANL"]]
+      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
 
       qenv <- common_code_q()
 
@@ -882,7 +882,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
               all_categories <- lapply(
                 unique(ANL[[categorical_var]]),
                 function(x) {
-                  ANL <- ANL %>% dplyr::filter(get(categorical_var) == x) # nolint: object_name.
+                  ANL <- ANL %>% dplyr::filter(get(categorical_var) == x)
                   anl_outlier2 <- ANL_OUTLIER %>% dplyr::filter(get(categorical_var) == x)
                   ecdf_df <- ANL %>%
                     dplyr::mutate(y = stats::ecdf(ANL[[outlier_var]])(ANL[[outlier_var]]))
@@ -1059,7 +1059,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
     choices <- teal.transform::variable_choices(data()[[dataname_first]])
 
     observeEvent(common_code_q(), {
-      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
+      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
       teal.widgets::updateOptionalSelectInput(
         session,
         inputId = "table_ui_columns",
@@ -1076,9 +1076,9 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)
         categorical_var <- as.vector(merged$anl_input_r()$columns_source$categorical_var)
 
-        ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
-        ANL_OUTLIER_EXTENDED <- common_code_q()[["ANL_OUTLIER_EXTENDED"]] # nolint: object_name.
-        ANL <- common_code_q()[["ANL"]] # nolint: object_name.
+        ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
+        ANL_OUTLIER_EXTENDED <- common_code_q()[["ANL_OUTLIER_EXTENDED"]]
+        ANL <- common_code_q()[["ANL"]]
 
         plot_brush <- if (tab == "Boxplot") {
           boxplot_r()
@@ -1092,7 +1092,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
         }
 
         # removing unused column ASAP
-        ANL_OUTLIER$order <- ANL$order <- NULL # nolint: object_name.
+        ANL_OUTLIER$order <- ANL$order <- NULL
 
         display_table <- if (!is.null(plot_brush)) {
           if (length(categorical_var) > 0) {
@@ -1108,7 +1108,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
             if (tab == "Boxplot") {
               # in boxplot with no categorical variable, there is no column in ANL that would correspond to x-axis
               # so a column needs to be inserted with the value "Entire dataset" because that's the label used in plot
-              ANL[[plot_brush$mapping$x]] <- "Entire dataset" # nolint: object_name.
+              ANL[[plot_brush$mapping$x]] <- "Entire dataset"
             }
           }
 
@@ -1116,16 +1116,16 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
           # so they need to be computed and attached to ANL
           if (tab == "Density Plot") {
             plot_brush$mapping$y <- "density"
-            ANL$density <- plot_brush$ymin # nolint: object_name.
+            ANL$density <- plot_brush$ymin
             # either ymin or ymax will work
           } else if (tab == "Cumulative Distribution Plot") {
             plot_brush$mapping$y <- "cdf"
             if (length(categorical_var) > 0) {
-              ANL <- ANL %>% # nolint: object_name.
+              ANL <- ANL %>%
                 dplyr::group_by(!!as.name(plot_brush$mapping$panelvar1)) %>%
                 dplyr::mutate(cdf = stats::ecdf(!!as.name(outlier_var))(!!as.name(outlier_var)))
             } else {
-              ANL$cdf <- stats::ecdf(ANL[[outlier_var]])(ANL[[outlier_var]]) # nolint: object_name.
+              ANL$cdf <- stats::ecdf(ANL[[outlier_var]])(ANL[[outlier_var]])
             }
           }
 
@@ -1170,10 +1170,10 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
 
     output$total_outliers <- renderUI({
       shiny::req(iv_r()$is_valid())
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
-      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
+      ANL_OUTLIER <- common_code_q()[["ANL_OUTLIER"]]
       teal::validate_has_data(ANL, 1)
-      ANL_OUTLIER_SELECTED <- ANL_OUTLIER[ANL_OUTLIER$is_outlier_selected, ] # nolint: object_name.
+      ANL_OUTLIER_SELECTED <- ANL_OUTLIER[ANL_OUTLIER$is_outlier_selected, ]
       h5(
         sprintf(
           "%s %d / %d [%.02f%%]",
@@ -1187,7 +1187,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
 
     output$total_missing <- renderUI({
       if (n_outlier_missing() > 0) {
-        ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+        ANL <- merged$anl_q_r()[["ANL"]]
         helpText(
           sprintf(
             "%s %d / %d [%.02f%%]",

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -302,7 +302,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
 
     output_q <- reactive({
       teal::validate_inputs(iv_r())
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint: object_name.
+      ANL <- merged$anl_q_r()[["ANL"]]
 
       # As this is a summary
       x_name <- as.vector(merged$anl_input_r()$columns_source$x)
@@ -386,7 +386,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
         teal.code::eval_code(
           substitute(
             expr = {
-              ANL <- tern::df_explicit_na(ANL) # nolint: object_name.
+              ANL <- tern::df_explicit_na(ANL)
               tbl <- rtables::build_table(lyt = lyt, df = ANL[order(ANL[[y_name]]), ])
               tbl
             },

--- a/data-raw/data.R
+++ b/data-raw/data.R
@@ -1,16 +1,16 @@
 ## code to prepare `data` for testing examples
 library(scda)
-rADAE <- synthetic_cdisc_data("latest")$adae # nolint: object_name.
+rADAE <- synthetic_cdisc_data("latest")$adae
 usethis::use_data(rADAE)
 
-rADLB <- synthetic_cdisc_data("latest")$adlb # nolint: object_name.
+rADLB <- synthetic_cdisc_data("latest")$adlb
 usethis::use_data(rADLB)
 
-rADRS <- synthetic_cdisc_data("latest")$adrs # nolint: object_name.
+rADRS <- synthetic_cdisc_data("latest")$adrs
 usethis::use_data(rADRS)
 
-rADSL <- synthetic_cdisc_data("latest")$adsl # nolint: object_name.
+rADSL <- synthetic_cdisc_data("latest")$adsl
 usethis::use_data(rADSL)
 
-rADTTE <- synthetic_cdisc_data("latest")$adtte # nolint: object_name.
+rADTTE <- synthetic_cdisc_data("latest")$adtte
 usethis::use_data(rADTTE)


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

- Part of #624
- Extends ANL rule to allow `ANL_OUTLIERS` and others variables that are prefixed with `ANL_` (in all caps)
