### PR TITLE
Fix the typo on tags$strong

### DIFF
--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -434,7 +434,7 @@ ui_g_scatterplot <- function(id, ...) {
             uiOutput(ns("num_na_removed")),
             tags$div(
               id = ns("label_pos"),
-              tags$div(tags$strog("Stats position")),
+              tags$div(tags$strong("Stats position")),
               tags$div(class = "inline-block w-10", helpText("Left")),
               tags$div(
                 class = "inline-block w-70",


### PR DESCRIPTION
Fixes the following example app:

```r
devtools::load_all()

data <- teal_data()
data <- within(data, {
  library(scda)
  library(scda.2022)
  ADSL <- synthetic_cdisc_dataset("latest", "adsl")
})

datanames <- "ADSL"
datanames(data) <- datanames

join_keys(data) <- default_cdisc_join_keys[datanames]

## Reusable Configuration For Modules
ADSL <- data[["ADSL"]]

adsl_extracted_num <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "AGE",
    multiple = FALSE,
    fixed = FALSE
  )
)
adsl_extracted_num2 <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL),
    selected = "BMRKR1",
    multiple = FALSE,
    fixed = FALSE
  )
)
fact_vars_adsl <- names(Filter(isTRUE, sapply(ADSL, is.factor)))
adsl_extracted_factors <- data_extract_spec(
  dataname = "ADSL",
  select = select_spec(
    choices = variable_choices(ADSL, subset = fact_vars_adsl),
    selected = NULL,
    multiple = FALSE,
    fixed = FALSE
  )
)

app <- init(
  data = data,
  modules = tm_g_scatterplot(
    "Scatterplot",
    x = adsl_extracted_num,
    y = adsl_extracted_num2,
    row_facet = adsl_extracted_factors,
    col_facet = adsl_extracted_factors,
    color_by = adsl_extracted_factors,
    size = 3, alpha = 1,
    plot_height = c(600L, 200L, 2000L)
  )
)

shinyApp(app$ui, app$server)
```