### PR TITLE
712 - `{shinytest2}` Injects `library` of tmg for shiny app

### DIFF
--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -1,6 +1,6 @@
 # Initialization function to create a new TealAppDriver object
 #
-# By manipulating the server function as below, we can hint shinytest2 to load
+# By manipulating the server function as below, we can hint {shinytest2} to load
 # this package and its "Depends".
 # Related to https://github.com/rstudio/shinytest2/issues/381
 init_teal_app_driver <- function(...) {
@@ -19,7 +19,7 @@ init_teal_app_driver <- function(...) {
       shiny::shinyApp(ui, server, ...)
     },
     # The relevant shinyApp call in `TealAppDriver` is being called without prefix,
-    # hence why the package bindings that is changed is in `{teal}` and not `{shiny}`
+    # hence why the package bindings that is changed is in {teal} and not {shiny}
     .package = "teal"
   )
 }

--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -11,21 +11,12 @@ init_teal_app_driver <- function(...) {
       TealAppDriver$new(...)
     },
     shinyApp = function(ui, server, ...) {
-      # Load the package in the environment where the server function is defined
-      # The pkgload::load_all() method is used on interactive and has a caveat
-      # when one of the functions use `system.file` as it may return an empty
-      # string
       functionBody(server) <- bquote({
-        pkgload::load_all(
-          .(normalizePath(file.path(testthat::test_path(), "..", ".."))),
-          export_all = FALSE,
-          attach_testthat = FALSE,
-          warn_conflicts = FALSE
-        )
-        library(.(testthat::testing_package()), character.only = TRUE)
+        # Hint to shinytest2 that this package is should be available (via {globals})
+        .local_add_facet_labels <- add_facet_labels
         .(functionBody(server))
       })
-      print(server)
+
       do.call(shiny__shinyApp, append(x = list(ui = ui, server = server), list(...)))
     },
     # shinyApp is being called without prefix, so it needs to be mocked in {teal}

--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -1,7 +1,7 @@
 # Initialization function to create a new TealAppDriver object
 #
-# It handles the library loading of itself and necessary packages used without
-# package prefixes.
+# By manipulating the server function as below, we can hint shinytest2 to load
+# this package and its "Depends".
 # Related to https://github.com/rstudio/shinytest2/issues/381
 init_teal_app_driver <- function(...) {
   shiny__shinyApp <- shiny::shinyApp # nolint: object_name.

--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -12,7 +12,7 @@ init_teal_app_driver <- function(...) {
     },
     shinyApp = function(ui, server, ...) {
       functionBody(server) <- bquote({
-        # Hint to shinytest2 that this package is should be available (via {globals})
+        # Hint to shinytest2 that this package should be available (via {globals})
         .hint_to_load_package <- add_facet_labels
         .(functionBody(server))
       })

--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -4,7 +4,6 @@
 # this package and its "Depends".
 # Related to https://github.com/rstudio/shinytest2/issues/381
 init_teal_app_driver <- function(...) {
-  shiny__shinyApp <- shiny::shinyApp # nolint: object_name.
   testthat::with_mocked_bindings(
     {
       TealAppDriver <- getFromNamespace("TealAppDriver", "teal") # nolint: object_name.
@@ -17,9 +16,10 @@ init_teal_app_driver <- function(...) {
         .(functionBody(server))
       })
 
-      do.call(shiny__shinyApp, append(x = list(ui = ui, server = server), list(...)))
+      shiny::shinyApp(ui, server, ...)
     },
-    # shinyApp is being called without prefix, so it needs to be mocked in {teal}
+    # The relevant shinyApp call in `TealAppDriver` is being called without prefix,
+    # hence why the package bindings that is changed is in `{teal}` and not `{shiny}`
     .package = "teal"
   )
 }

--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -13,7 +13,7 @@ init_teal_app_driver <- function(...) {
     shinyApp = function(ui, server, ...) {
       functionBody(server) <- bquote({
         # Hint to shinytest2 that this package is should be available (via {globals})
-        .local_add_facet_labels <- add_facet_labels
+        .hint_to_load_package <- add_facet_labels
         .(functionBody(server))
       })
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Part of #712 

### Changes description

- Changes `shinyApp` function used in `TealAppDriver` to trick `shinytest2` into loading the package
  - This allows the module server function to call package in `Depends` without prefixing

#### How to test?

- Checkout branch
- Save test below in the `tests/testthat` directory
- Restart R session (don't load package afterwards!)
- Run `devtools::test(filter = "test-remove_me.R")` or whatever name you use
- Run test interactively after loading package

```r
# Save in tests/testthat/test-remove_me.R
testthat::test_that("sample test", {

  # general data example
  data <- teal.data::teal_data()
  data <- within(data, {
    require(nestcolor)
    CO2 <- CO2
  })
  teal.data::datanames(data) <- "CO2"

  mod <- teal.modules.general::tm_g_scatterplot(
    label = "Scatterplot Choices",
    x = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(data[["CO2"]], c("conc", "uptake")),
        selected = "conc",
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    y = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(data[["CO2"]], c("conc", "uptake")),
        selected = "uptake",
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    color_by = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(
          data[["CO2"]],
          c("Plant", "Type", "Treatment", "conc", "uptake")
        ),
        selected = NULL,
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    size_by = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(data[["CO2"]], c("conc", "uptake")),
        selected = "uptake",
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    row_facet = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(data[["CO2"]], c("Plant", "Type", "Treatment")),
        selected = NULL,
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    col_facet = teal.transform::data_extract_spec(
      dataname = "CO2",
      select = teal.transform::select_spec(
        label = "Select variable:",
        choices = teal.transform::variable_choices(data[["CO2"]], c("Plant", "Type", "Treatment")),
        selected = NULL,
        multiple = FALSE,
        fixed = FALSE
      )
    ),
    ggplot2_args = teal.widgets::ggplot2_args(
      labs = list(subtitle = "Plot generated by Scatterplot Module")
    )
  )

  app_driver <- init_teal_app_driver(
    data = data,
    modules = list(mod)
  )

  app_driver$expect_no_validation_error()
})
```