### PR TITLE
fixing shinytest2 fail for tm_missing_data

### DIFF
--- a/tests/testthat/test-shinytest2-tm_misssing_data.R
+++ b/tests/testthat/test-shinytest2-tm_misssing_data.R
@@ -1,5 +1,6 @@
 app_driver_tm_missing_data <- function() {
   data <- within(simple_teal_data(), {
+    set.seed(123)
     require(nestcolor)
 
     add_nas <- function(x) {


### PR DESCRIPTION
A test in tm_missing_data is failing because a slider's default value gives an error. It passed in PR [727](https://github.com/insightsengineering/teal.modules.general/pull/727) with a value of 2L, but here it was showing 1L. I fixed it in PR [733](https://github.com/insightsengineering/teal.modules.general/pull/733) with app_driver$get_active_module_input("iris-combination_cutoff"), but it's causing an error in another PR again.

To fix I have set.seed in` teal_data()`