### PR TITLE
`shinyApp` chunk in vignettes only runs if is in interactive mode

### DIFF
--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -2,7 +2,6 @@
 title: "Using association plot"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using association plot}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-association-plot.Rmd
+++ b/vignettes/using-association-plot.Rmd
@@ -297,7 +297,7 @@ app <- init(
 
 A simple `shiny::shinyApp()` call will let you run the app. Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -623,7 +623,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-bivariate-plot.Rmd
+++ b/vignettes/using-bivariate-plot.Rmd
@@ -2,7 +2,6 @@
 title: "Using bivariate plot"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using bivariate plot}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -139,7 +139,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-cross-table.Rmd
+++ b/vignettes/using-cross-table.Rmd
@@ -2,7 +2,6 @@
 title: "Using cross table"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using cross table}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -2,7 +2,6 @@
 title: "Using data table"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using data table}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-data-table.Rmd
+++ b/vignettes/using-data-table.Rmd
@@ -110,7 +110,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app. 
 Note that app is only displayed when running this code inside an `R` session.  
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -191,7 +191,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app. 
 Note that app is only displayed when running this code inside an `R` session.  
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-outliers-module.Rmd
+++ b/vignettes/using-outliers-module.Rmd
@@ -2,7 +2,6 @@
 title: "Using outliers module"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using outliers module}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -270,7 +270,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-regression-plots.Rmd
+++ b/vignettes/using-regression-plots.Rmd
@@ -2,7 +2,6 @@
 title: "Using regression plots"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using regression plots}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -379,7 +379,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-response-plot.Rmd
+++ b/vignettes/using-response-plot.Rmd
@@ -2,7 +2,6 @@
 title: "Using response plot"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using response plot}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -157,7 +157,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-scatterplot-matrix.Rmd
+++ b/vignettes/using-scatterplot-matrix.Rmd
@@ -2,7 +2,6 @@
 title: "Using scatterplot matrix"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using scatterplot matrix}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -377,7 +377,7 @@ app <- init(
 A simple `shiny::shinyApp()` call will let you run the app.
 Note that app is only displayed when running this code inside an `R` session.
 
-```{r, echo=TRUE, results="hide"}
+```{r, echo=TRUE, results="hide", eval=base::interactive()}
 shinyApp(app$ui, app$server, options = list(height = 1024, width = 1024))
 ```
 

--- a/vignettes/using-scatterplot.Rmd
+++ b/vignettes/using-scatterplot.Rmd
@@ -2,7 +2,6 @@
 title: "Using scatterplot"
 author: "NEST CoreDev"
 output: rmarkdown::html_vignette
-runtime: shiny
 vignette: >
   %\VignetteIndexEntry{Using scatterplot}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
# Pull Request

- Fixes #740
- Fixes #729

#### Changes description

- add `eval=base::interactive()` to chunk options in vignettes

### How to test

- Run `rmcdcheck::rmcdcheck()`
- Run `scheduled.yaml` Github action and all strategies complete successfully
  - Currently they're taking 6h+ hours and failing
  - Badge for this branch: [![Scheduled 🕰️](https://github.com/insightsengineering/teal.modules.general/actions/workflows/scheduled.yaml/badge.svg?branch=740-vignettes-shinyapp%40main)](https://github.com/insightsengineering/teal.modules.general/actions/workflows/scheduled.yaml)