### PR TITLE
vbump testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,7 +75,7 @@ Suggests:
     rvest,
     shinytest2,
     sparkline,
-    testthat (>= 3.0.4),
+    testthat (>= 3.1.9),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr


### PR DESCRIPTION
fix min_isolated strategy
https://github.com/insightsengineering/teal.modules.general/actions/runs/9630557319/job/26561246365
```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-examples.R:143:1): (code run outside of `test_that()`) ──────────
Error: 'is_checking' is not an exported object from 'namespace:testthat'
Backtrace:
    ▆
 1. └─teal.modules.general (local) rd_files() at test-examples.R:143:1
── Error (test-tm_g_bivariate.R:243:3): tm_g_bivariate determines `color`, `size` and `fill` when `color_setting` is TRUE ──
Error: 'expect_contains' is not an exported object from 'namespace:testthat'

[ FAIL 2 | WARN 0 | SKIP 78 | PASS 66 ]
```

`is_checking` is available since [`3.1.9`](https://github.com/cran/testthat/blob/3.1.9/NAMESPACE#L82) (and it's missing in [`3.1.8`](https://github.com/cran/testthat/blob/3.1.8/NAMESPACE))

test runs available here: https://github.com/insightsengineering/teal.modules.general/actions/workflows/scheduled.yaml?query=branch%3Apawelru-patch-1