### PR TITLE
add setup-r-dependencies

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,6 +42,20 @@ jobs:
         checking top-level files .* NOTE
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -64,6 +78,20 @@ jobs:
         checking Rd .usage sections .* NOTE
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -72,6 +100,20 @@ jobs:
     with:
       additional-env-vars: |
         NOT_CRAN=true
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -83,6 +125,20 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       auto-update: true
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,3 +42,17 @@ jobs:
     with:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,41 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       default-landing-page: latest-tag
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/nestcolor
+        insightsengineering/roxy.shinylive
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   validation:
     name: R Package Validation report 📃
     needs: release
     uses: insightsengineering/r.pkg.template/.github/workflows/validation.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/nestcolor
+        insightsengineering/roxy.shinylive
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -46,6 +75,20 @@ jobs:
         checking top-level files .* NOTE
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -55,6 +98,20 @@ jobs:
     with:
       additional-env-vars: |
         NOT_CRAN=true
+      deps-installation-method: setup-r-dependencies
+      lookup-refs: |
+        insightsengineering/roxy.shinylive
+        insightsengineering/teal
+        insightsengineering/teal.transform
+        insightsengineering/teal.code
+        insightsengineering/teal.data
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/tern
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -3,7 +3,7 @@ name: Scheduled 🕰️
 
 on:
   schedule:
-    - cron: '45 3 * * 0'
+    - cron: "45 3 * * 0"
   workflow_dispatch:
     inputs:
       chosen-workflow:
@@ -63,12 +63,13 @@ jobs:
         insightsengineering/teal.transform
         insightsengineering/teal.code
         insightsengineering/teal.data
-        insightsengineering/teal.slice
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
         insightsengineering/tern
         insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -84,9 +85,10 @@ jobs:
         insightsengineering/teal.transform
         insightsengineering/teal.code
         insightsengineering/teal.data
-        insightsengineering/teal.slice
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
         insightsengineering/tern
         insightsengineering/rtables
+        insightsengineering/rtables.officer
+        insightsengineering/nestcolor


### PR DESCRIPTION
Related to https://github.com/insightsengineering/nestdevs-tasks/issues/65
Switch to setup-r-dependencies.
Added `teal.modules.general` for lookup-refs.
