### PR TITLE
add a check for non-unique decorator names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -355,7 +355,7 @@ check_decorators <- function(x, names = NULL) { # nolint: object_name.
         if (isTRUE(out_message)) {
           out_message <- unique_message
         } else {
-          out_message <- paste0(out_message, '. Also, ', tolower(unique_message))
+          out_message <- paste0(out_message, ". Also, ", tolower(unique_message))
         }
       }
       if (isTRUE(out_message)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -351,7 +351,12 @@ check_decorators <- function(x, names = NULL) { # nolint: object_name.
       out_message <- checkmate::check_names(names(x), subset.of = c("default", names))
       # see https://github.com/insightsengineering/teal.logger/issues/101
       if (length(names(x)) != length(unique(names(x)))) {
-        out_message <- "Non-unique names in decorators."
+        unique_message <- "Non-unique names in decorators"
+        if (isTRUE(out_message)) {
+          out_message <- unique_message
+        } else {
+          out_message <- paste0(out_message, '. Also, ', tolower(unique_message))
+        }
       }
       if (isTRUE(out_message)) {
         out_message

--- a/R/utils.R
+++ b/R/utils.R
@@ -350,6 +350,9 @@ check_decorators <- function(x, names = NULL) { # nolint: object_name.
     check_message <- if (isTRUE(check_message)) {
       out_message <- checkmate::check_names(names(x), subset.of = c("default", names))
       # see https://github.com/insightsengineering/teal.logger/issues/101
+      if (length(names(x)) != length(unique(names(x)))) {
+        out_message <- "Non-unique names in decorators."
+      }
       if (isTRUE(out_message)) {
         out_message
       } else {


### PR DESCRIPTION
The same as in tmc
https://github.com/insightsengineering/teal.modules.clinical/pull/1313/commits/b048f3744c475e3a2e19733d0b34d71061548faf
do not allow decorators with duplicated names