### PR TITLE
simplify builds dependencies of extra-deps

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -39,7 +39,7 @@ jobs:
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
       extra-deps: |
-        MultiAssayExperiment (>= 1.32.0);SummarizedExperiment (>= 1.36.0);teal.slice (>= 0.5.1.9021)
+        matrixStats (>= 1.5.0)
   branch-cleanup:
     if: >
       github.event_name == 'schedule' || (


### PR DESCRIPTION
Companion to that allows to use older MultiAssayExperiment and older SummarizedExperiment 
More explanation in here https://github.com/insightsengineering/teal.slice/pull/637#issuecomment-2607373951

https://github.com/insightsengineering/teal/pull/1460
https://github.com/insightsengineering/teal.slice/pull/637