### PR TITLE
Allow search in tm_file_viewer

### DIFF
--- a/R/tm_file_viewer.R
+++ b/R/tm_file_viewer.R
@@ -116,7 +116,8 @@ ui_viewer <- function(id, ...) {
           dragAndDrop = FALSE,
           sort = FALSE,
           theme = "proton",
-          multiple = FALSE
+          multiple = FALSE,
+          search = TRUE
         )
       )
     )


### PR DESCRIPTION
Fixes #152 

Just adding `search = TRUE` argument
<img width="293" alt="image" src="https://github.com/user-attachments/assets/6aa27866-ba28-4c9a-8844-d6671845fe07" />
