### PR TITLE
`{teal}` module returns a `teal_report` object that extends from `teal_data`

### DIFF
--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -1038,9 +1038,8 @@ srv_a_pca <- function(id, data, reporter, filter_panel_api, dat, plot_height, pl
           data = q,
           decorators = select_decorators(decorators, obj_name),
           expr = reactive({
-            substitute(print(.plot), env = list(.plot = as.name(obj_name)))
-          }),
-          expr_is_reactive = TRUE
+            substitute(.plot, env = list(.plot = as.name(obj_name)))
+          })
         )
       },
       names(output_q),

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -462,9 +462,11 @@ srv_a_regression <- function(id,
       )
     })
 
-    qenv <- reactive(
-      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes
-    )
+    qenv <- reactive({
+      obj <- data()
+      teal.reporter::report(obj) <- c(teal.reporter::report(obj), "# Module's computation")
+      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint quotes
+    })
 
     anl_merged_q <- reactive({
       req(anl_merged_input())
@@ -991,8 +993,6 @@ srv_a_regression <- function(id,
         "Residuals vs Leverage" = output_plot_5(),
         "Cook's dist vs Leverage" = output_plot_6()
       )
-
-      teal.data::report(obj) <- c(teal.data::report(obj), "# Plot", obj[["plot"]])
       obj
     })
 
@@ -1000,7 +1000,7 @@ srv_a_regression <- function(id,
       "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = print(plot)
+      expr = quote(plot)
     )
 
     fitted <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -525,10 +525,7 @@ srv_tm_g_association <- function(id,
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = quote({
-        grid::grid.newpage()
-        grid::grid.draw(plot)
-      })
+      expr = quote(plot)
     )
 
     plot_r <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -525,10 +525,10 @@ srv_tm_g_association <- function(id,
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = {
+      expr = quote({
         grid::grid.newpage()
         grid::grid.draw(plot)
-      }
+      })
     )
 
     plot_r <- reactive({

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -347,7 +347,7 @@ srv_tm_g_association <- function(id,
     )
 
     qenv <- reactive(
-      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr");library("tern");library("ggmosaic")') # nolint quotes
+      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr");library("ggmosaic")') # nolint quotes
     )
     anl_merged_q <- reactive({
       req(anl_merged_input())
@@ -506,9 +506,7 @@ srv_tm_g_association <- function(id,
           substitute(
             expr = {
               plots <- plot_calls
-              plot_top <- plots[[1]]
-              plot_bottom <- plots[[2]]
-              plot <- tern::stack_grobs(grobs = lapply(list(plot_top, plot_bottom), ggplot2::ggplotGrob))
+              plot <- grid.arrange(plots[[1]], plots[[2]], ncol = 1)
             },
             env = list(
               plot_calls = do.call(

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -711,7 +711,7 @@ srv_g_bivariate <- function(id,
         without_facet <- (is.null(nulled_row_facet_name) && is.null(nulled_col_facet_name)) || !facetting
 
         print_call <- if (without_facet) {
-          quote(print(plot))
+          quote(plot)
         } else {
           substitute(
             expr = {
@@ -730,8 +730,7 @@ srv_g_bivariate <- function(id,
           )
         }
         print_call
-      }),
-      expr_is_reactive = TRUE
+      })
     )
 
     plot_r <- reactive(req(decorated_output_q_facets())[["plot"]])

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -1297,28 +1297,28 @@ srv_distribution <- function(id,
       "d_density",
       data = output_dist_q,
       decorators = select_decorators(decorators, "histogram_plot"),
-      expr = print(histogram_plot)
+      expr = quote(histogram_plot)
     )
 
     decorated_output_qq_q <- srv_decorate_teal_data(
       "d_qq",
       data = output_qq_q,
       decorators = select_decorators(decorators, "qq_plot"),
-      expr = print(qq_plot)
+      expr = quote(qq_plot)
     )
 
     decorated_output_summary_q <- srv_decorate_teal_data(
       "d_summary",
       data = output_summary_q,
       decorators = select_decorators(decorators, "summary_table"),
-      expr = summary_table
+      expr = quote(summary_table)
     )
 
     decorated_output_test_q <- srv_decorate_teal_data(
       "d_test",
       data = output_test_q,
       decorators = select_decorators(decorators, "test_table"),
-      expr = test_table
+      expr = quote(test_table)
     )
 
     decorated_output_q <- reactive({

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -579,7 +579,7 @@ srv_g_response <- function(id,
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = print(plot)
+      expr = quote(plot)
     )
 
     plot_r <- reactive(req(decorated_output_plot_q())[["plot"]])

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -1023,7 +1023,7 @@ srv_g_scatterplot <- function(id,
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = print(plot)
+      expr = quote(plot)
     )
 
     plot_r <- reactive(req(decorated_output_plot_q())[["plot"]])

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -464,7 +464,7 @@ srv_g_scatterplotmatrix <- function(id,
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "plot"),
-      expr = print(plot)
+      expr = quote(plot)
     )
 
     plot_r <- reactive(req(decorated_output_q())[["plot"]])

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -1269,34 +1269,34 @@ srv_missing_data <- function(id,
       id = "dec_summary_plot",
       data = summary_plot_q,
       decorators = select_decorators(decorators, "summary_plot"),
-      expr = {
+      expr = quote({
         grid::grid.newpage()
         grid::grid.draw(summary_plot)
-      }
+      })
     )
 
     decorated_combination_plot_q <- srv_decorate_teal_data(
       id = "dec_combination_plot",
       data = combination_plot_q,
       decorators = select_decorators(decorators, "combination_plot"),
-      expr = {
+      expr = quote({
         grid::grid.newpage()
         grid::grid.draw(combination_plot)
-      }
+      })
     )
 
     decorated_summary_table_q <- srv_decorate_teal_data(
       id = "dec_summary_table",
       data = summary_table_q,
       decorators = select_decorators(decorators, "table"),
-      expr = table
+      expr = quote(table)
     )
 
     decorated_by_subject_plot_q <- srv_decorate_teal_data(
       id = "dec_by_subject_plot",
       data = by_subject_plot_q,
       decorators = select_decorators(decorators, "by_subject_plot"),
-      expr = print(by_subject_plot)
+      expr = quote(by_subject_plot)
     )
 
     # Plots & tables reactives

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -1037,8 +1037,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
               },
               env = list(table_columns = input$table_ui_columns, .plot = as.name(obj_name))
             )
-          }),
-          expr_is_reactive = TRUE
+          })
         )
       },
       stats::setNames(nm = c("box_plot", "density_plot", "cumulative_plot")),
@@ -1051,7 +1050,7 @@ srv_outliers <- function(id, data, reporter, filter_panel_api, outlier_var,
       "d_table",
       data = decorated_final_q_no_table,
       decorators = select_decorators(decorators, "table"),
-      expr = table
+      expr = quote(table)
     )
 
     output$summary_table <- DT::renderDataTable(

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -427,7 +427,7 @@ srv_t_crosstable <- function(id, data, reporter, filter_panel_api, label, x, y, 
       id = "decorator",
       data = output_q,
       decorators = select_decorators(decorators, "table"),
-      expr = table
+      expr = quote(table)
     )
 
     output$title <- renderText(req(decorated_output_q())[["title"]])


### PR DESCRIPTION
# Pull Request

Fixes:

- https://github.com/insightsengineering/teal/issues/1526

Built on top of:

- https://github.com/insightsengineering/teal/pull/1499 _(will be closed once this PR is stable)_

### Companion PRs:

- https://github.com/insightsengineering/teal.reporter/pull/331
- https://github.com/insightsengineering/teal.data/pull/370
- https://github.com/insightsengineering/teal.code/pull/255

### Changes description

- [x] Return a `teal_report` object on every module
- [ ] Remove old "Add to reporter" implementation in modules
