### PR TITLE
Naming

### DIFF
--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -464,7 +464,7 @@ srv_a_regression <- function(id,
 
     qenv <- reactive({
       obj <- data()
-      teal.reporter::report(obj) <- c(teal.reporter::report(obj), "# Module's computation")
+      teal.reporter::document(obj) <- c(teal.reporter::document(obj), "# Module's computation")
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint quotes
     })
 

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -464,7 +464,7 @@ srv_a_regression <- function(id,
 
     qenv <- reactive({
       obj <- data()
-      teal.reporter::card(obj) <- c(teal.reporter::card(obj), "# Module's computation")
+      teal.reporter::teal_card(obj) <- c(teal.reporter::teal_card(obj), "# Module's computation")
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint quotes
     })
 

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -464,7 +464,7 @@ srv_a_regression <- function(id,
 
     qenv <- reactive({
       obj <- data()
-      teal.reporter::teal_document(obj) <- c(teal.reporter::teal_document(obj), "# Module's computation")
+      teal.reporter::card(obj) <- c(teal.reporter::card(obj), "# Module's computation")
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint quotes
     })
 

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -464,7 +464,7 @@ srv_a_regression <- function(id,
 
     qenv <- reactive({
       obj <- data()
-      teal.reporter::document(obj) <- c(teal.reporter::document(obj), "# Module's computation")
+      teal.reporter::teal_document(obj) <- c(teal.reporter::teal_document(obj), "# Module's computation")
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint quotes
     })
 


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal.reporter/pull/334
Consequence of changing naming convention for `teal_report` object.