### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Imports:
     utils
 Suggests:
     knitr (>= 1.42),
-    logger (>= 0.2.0),
+    logger (>= 0.4.0),
     nestcolor (>= 0.1.0),
     pkgload,
     rlang (>= 1.0.0),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.