### PR TITLE
fix label logic

### DIFF
--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -601,7 +601,12 @@ srv_distribution <- function(id,
           gamma = c("shape", "rate"),
           unif = c("min", "max")
         )
-        params_names <- map_distr_nams[[input$t_dist]] %||% names(params)
+
+        if (!is.null(input$t_dist) && input$t_dist %in% names(map_distr_nams)) {
+          params_names <- map_distr_nams[[input$t_dist]]
+        } else {
+          params_names <- names(params)
+        }
 
         updateNumericInput(
           inputId = "dist_param1",

--- a/man/srv_decorate_teal_data.Rd
+++ b/man/srv_decorate_teal_data.Rd
@@ -12,7 +12,8 @@ ui_decorate_teal_data(id, decorators, ...)
 \arguments{
 \item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
-\item{data}{(\code{reactive} returning \code{teal_data})}
+\item{data}{(\code{teal_data}, \code{teal_data_module}, or \code{reactive} returning \code{teal_data})
+The data which application will depend on.}
 
 \item{expr}{(\code{expression} or \code{reactive}) to evaluate on the output of the decoration.
 When an expression it must be inline code. See \code{\link[=within]{within()}}


### PR DESCRIPTION
Fixes #510 
* Improve the logic to define `params_names`

<details>

<summary>Example Code 1</summary>

```r
data <- teal_data()
data <- within(data, {
  iris <- iris
})
#'
app <- init(
  data = data,
  modules = list(
    tm_g_distribution(
      dist_var = data_extract_spec(
        dataname = "iris",
        select = select_spec(variable_choices("iris"), "Petal.Length")
      )
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>

<details>

<summary>Example Code 2 where nothing is selected</summary>

```r
data <- teal_data()
data <- within(data, {
  ADSL <- teal.data::rADSL
})
join_keys(data) <- default_cdisc_join_keys[names(data)]
#'
vars1 <- choices_selected(
  variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),
  selected = NULL
)
#'
app <- init(
  data = data,
  modules = modules(
    tm_g_distribution(
      dist_var = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          choices = variable_choices(data[["ADSL"]], c("AGE", "BMRKR1")),
          selected = NULL,
          multiple = FALSE,
          fixed = FALSE
        )
      ),
      strata_var = data_extract_spec(
        dataname = "ADSL",
        filter = filter_spec(
          vars = vars1,
          multiple = TRUE
        )
      ),
      group_var = data_extract_spec(
        dataname = "ADSL",
        filter = filter_spec(
          vars = vars1,
          multiple = TRUE
        )
      )
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>
