### PR TITLE
Bump version of shiny to support `bslib` and align with `teal`'s min `shiny` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Depends:
     ggmosaic (>= 0.3.0),
     ggplot2 (>= 3.4.0),
     R (>= 4.1),
-    shiny (>= 1.6.0),
+    shiny (>= 1.8.1),
     teal (>= 0.16.0.9008),
     teal.transform (>= 0.6.0.9002)
 Imports:


### PR DESCRIPTION
Bump shiny version as per the discussion https://github.com/insightsengineering/teal.widgets/pull/312#discussion_r2250985703