### PR TITLE
Update lifecycle badges

### DIFF
--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -112,7 +112,7 @@ tm_data_table <- function(label = "Data Table",
     })
   }
   if (!missing(datasets_selected)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_stop(
       when = "0.4.0",
       what = "tm_data_table(datasets_selected)",
       with = "tm_data_table(datanames)",

--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -83,7 +83,7 @@ tm_front_page <- function(label = "Front page",
   checkmate::assert_multi_class(additional_tags, classes = c("shiny.tag.list", "html"))
   checkmate::assert_character(footnotes, min.len = 0, any.missing = FALSE)
   if (!missing(show_metadata)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_stop(
       when = "0.4.0",
       what = "tm_front_page(show_metadata)",
       with = "tm_front_page(datanames)",

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -91,7 +91,7 @@ tm_variable_browser <- function(label = "Variable Browser",
   # Start of assertions
   checkmate::assert_string(label)
   if (!missing(datasets_selected)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_stop(
       when = "0.4.0",
       what = "tm_variable_browser(datasets_selected)",
       with = "tm_variable_browser(datanames)",


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/649

Changed deprecate soft -> deprecate hard for badges introduced in 0.4.0. Next release is 0.4.2 or higher.