### PR TITLE
Replace table by plot on tm_missing_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,7 @@ Imports:
     tools,
     utils
 Suggests:
+    formatters (>= 0.5.11),
     knitr (>= 1.42),
     logger (>= 0.4.0),
     nestcolor (>= 0.1.0),

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -440,7 +440,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
           teal.reporter::teal_card(obj),
           teal.reporter::teal_card("## Module's code")
         )
-      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("tidyr")') # nolint: quotes
+      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("tidyr")') # nolint: quotes_lintr
     })
     anl_merged_q <- reactive({
       req(anl_merged_input())

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -37,9 +37,9 @@
 #'     It takes the form of `c(value, min, max)` and it is passed to the `value_min_max`
 #'     argument in `teal.widgets::optionalSliderInputValMinMax`.
 #'
-# nolint start: line_length.
+# nolint start: line_length_lintr.
 #' @param ggplot2_args `r roxygen_ggplot2_args_param("Response vs Regressor", "Residuals vs Fitted", "Scale-Location", "Cook's distance", "Residuals vs Leverage", "Cook's dist vs Leverage")`
-# nolint end: line_length.
+# nolint end: line_length_lintr.
 #'
 #' @inherit shared_params return
 #'
@@ -465,7 +465,7 @@ srv_a_regression <- function(id,
           teal.reporter::teal_card(obj),
           teal.reporter::teal_card("## Module's code")
         )
-      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint: quotes
+      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint: quotes_lintr
     })
 
     anl_merged_q <- reactive({

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -309,7 +309,7 @@ srv_data_table <- function(id,
       teal::validate_has_data(df, min_nrow = 1L, msg = paste("data", dataname, "is empty"))
       qenv <- teal.code::eval_code(
         data(),
-        'library("dplyr");library("DT")' # nolint: quotes.
+        'library("dplyr");library("DT")' # nolint: quotes_lintr.
       )
       teal.code::eval_code(
         qenv,

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -151,8 +151,8 @@ tm_g_association <- function(label = "Association",
                              show_association = TRUE,
                              plot_height = c(600, 400, 5000),
                              plot_width = NULL,
-                             distribution_theme = c("gray", "bw", "linedraw", "light", "dark", "minimal", "classic", "void"), # nolint: line_length.
-                             association_theme = c("gray", "bw", "linedraw", "light", "dark", "minimal", "classic", "void"), # nolint: line_length.
+                             distribution_theme = c("gray", "bw", "linedraw", "light", "dark", "minimal", "classic", "void"), # nolint: line_length_lintr.
+                             association_theme = c("gray", "bw", "linedraw", "light", "dark", "minimal", "classic", "void"), # nolint: line_length_lintr.
                              pre_output = NULL,
                              post_output = NULL,
                              ggplot2_args = teal.widgets::ggplot2_args(),
@@ -349,7 +349,7 @@ srv_tm_g_association <- function(id,
           teal.reporter::teal_card(obj),
           teal.reporter::teal_card("## Module's code")
         )
-      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("ggmosaic")') # nolint: quotes
+      teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("ggmosaic")') # nolint: quotes_lintr
     })
     anl_merged_q <- reactive({
       req(anl_merged_input())

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -565,7 +565,7 @@ srv_g_bivariate <- function(id,
       obj %>%
         teal.code::eval_code(
           c(
-            'library("ggplot2");library("dplyr")', # nolint: quotes
+            'library("ggplot2");library("dplyr")', # nolint: quotes_lintr
             as.expression(anl_merged_input()$expr)
           )
         )

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -524,7 +524,7 @@ srv_distribution <- function(id,
     )
 
     qenv <- reactive(
-      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes
+      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes_lintr
     )
 
     anl_merged_q <- reactive({
@@ -665,7 +665,7 @@ srv_distribution <- function(id,
             "Group by variable must be `factor`, `character`, or `integer`"
           )
         )
-        qenv <- teal.code::eval_code(qenv, 'library("forcats")') # nolint quotes
+        qenv <- teal.code::eval_code(qenv, 'library("forcats")') # nolint quotes_lintr
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
@@ -683,7 +683,7 @@ srv_distribution <- function(id,
           )
         )
 
-        qenv <- teal.code::eval_code(qenv, 'library("forcats")') # nolint quotes
+        qenv <- teal.code::eval_code(qenv, 'library("forcats")') # nolint quotes_lintr
         qenv <- teal.code::eval_code(
           qenv,
           substitute(
@@ -893,7 +893,7 @@ srv_distribution <- function(id,
         }
 
         if (length(t_dist) != 0 && main_type_var == "Density" && length(g_var) == 0 && length(s_var) == 0) {
-          qenv <- teal.code::eval_code(qenv, 'library("ggpp")') # nolint quotes
+          qenv <- teal.code::eval_code(qenv, 'library("ggpp")') # nolint quotes_lintr
           qenv <- teal.code::eval_code(
             qenv,
             substitute(
@@ -1039,7 +1039,7 @@ srv_distribution <- function(id,
         )
 
         if (length(t_dist) != 0 && length(g_var) == 0 && length(s_var) == 0) {
-          qenv <- teal.code::eval_code(qenv, 'library("ggpp")') # nolint quotes
+          qenv <- teal.code::eval_code(qenv, 'library("ggpp")') # nolint quotes_lintr
           qenv <- teal.code::eval_code(
             qenv,
             substitute(
@@ -1235,7 +1235,7 @@ srv_distribution <- function(id,
         qenv <- common_q()
 
         if (length(s_var) == 0 && length(g_var) == 0) {
-          qenv <- teal.code::eval_code(qenv, 'library("generics")') # nolint quotes
+          qenv <- teal.code::eval_code(qenv, 'library("generics")') # nolint quotes_lintr
           qenv <- teal.code::eval_code(
             qenv,
             substitute(
@@ -1249,7 +1249,7 @@ srv_distribution <- function(id,
             )
           )
         } else {
-          qenv <- teal.code::eval_code(qenv, 'library("tidyr")') # nolint quotes
+          qenv <- teal.code::eval_code(qenv, 'library("tidyr")') # nolint quotes_lintr
           qenv <- teal.code::eval_code(
             qenv,
             substitute(

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -390,7 +390,7 @@ srv_g_response <- function(id,
     )
 
     qenv <- reactive(
-      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes
+      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes_lintr
     )
 
     anl_merged_q <- reactive({
@@ -524,7 +524,7 @@ srv_g_response <- function(id,
             resp_cl = resp_cl,
             hjust_value = if (swap_axes) "left" else "middle",
             vjust_value = if (swap_axes) "middle" else -1,
-            position_anl2_value = if (!freq) quote(position_fill(0.5)) else quote(position_stack(0.5)), # nolint: line_length.
+            position_anl2_value = if (!freq) quote(position_fill(0.5)) else quote(position_stack(0.5)), # nolint: line_length_lintr.
             anl3_y = if (!freq) 1.1 else as.name("ns"),
             position_anl3_value = if (!freq) "fill" else "stack"
           )

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -591,7 +591,7 @@ srv_g_scatterplot <- function(id,
         teal.reporter::teal_card(obj),
         teal.reporter::teal_card("## Module's code")
       )
-      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes
+      teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes_lintr
     })
 
     anl_merged_q <- reactive({

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -334,7 +334,7 @@ srv_g_scatterplotmatrix <- function(id,
         teal.reporter::teal_card(obj),
         teal.reporter::teal_card("## Module's code")
       )
-      qenv <- teal.code::eval_code(obj, 'library("dplyr");library("lattice")') # nolint quotes
+      qenv <- teal.code::eval_code(obj, 'library("dplyr");library("lattice")') # nolint quotes_lintr
       teal.code::eval_code(qenv, as.expression(anl_merged_input()$expr))
     })
 

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -330,8 +330,6 @@ ui_missing_data <- function(id, by_subject_plot = FALSE) {
     ),
     tabPanel(
       "By Variable Levels",
-      # teal.widgets::get_dt_rows(ns("levels_table"), ns("levels_table_rows")),
-      # DT::dataTableOutput(ns("levels_table"))
       teal.widgets::plot_with_settings_ui(id = ns("by_variable_plot")),
     )
   )
@@ -1173,7 +1171,7 @@ srv_missing_data <- function(id,
 
       # convert to ggplot
       if (!is.null(group_vals)) {
-        ANL_q <- within(qenv,
+        ANL_q <- within(qenv, #nolint object_name_linter
           {
             keep_columns <- intersect(c(keys, group_var), colnames(ANL))
             labels <- vapply(ANL, formatters::obj_label, character(1L))
@@ -1192,7 +1190,7 @@ srv_missing_data <- function(id,
           group_vals = group_vals
         )
       } else {
-        ANL_q <- within(qenv,
+        ANL_q <- within(qenv, #nolint object_name_linter
           {
             keep_columns <- intersect(c(keys, group_var), colnames(ANL))
             labels <- vapply(ANL, formatters::obj_label, character(1L))
@@ -1231,7 +1229,6 @@ srv_missing_data <- function(id,
         },
         labs = parsed_ggplot2_args$labs,
         labels = if (input$count_type == "counts") quote(ggplot2::waiver()) else quote(scales::label_percent()),
-        # low = if (input$count_type == "counts") "grey90" else "#ff2951ff",
         ggthemes = parsed_ggplot2_args$ggtheme
       )
       tile

--- a/man/tm_missing_data.Rd
+++ b/man/tm_missing_data.Rd
@@ -84,6 +84,7 @@ This module generates the following objects, which can be modified in place usin
 \itemize{
 \item \code{summary_plot} (\code{ggplot})
 \item \code{combination_plot} (\code{grob} created with \code{\link[ggplot2:ggplotGrob]{ggplot2::ggplotGrob()}})
+\item \code{by_variable_plot} (\code{ggplot})
 \item \code{by_subject_plot} (\code{ggplot})
 }
 
@@ -96,6 +97,7 @@ See code snippet below:
    decorators = list(
      summary_plot = teal_transform_module(...), # applied only to `summary_plot` output
      combination_plot = teal_transform_module(...), # applied only to `combination_plot` output
+     by_variable_plot = teal_transform_module(...) # applied only to `by_variable_plot` output
      by_subject_plot = teal_transform_module(...) # applied only to `by_subject_plot` output
    )
 )


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #495 

Replaces the table by a plot on "By Variables Levels" tab. 
The colors match those in the other plots of the module.
It also required to add a "new" dependency, formatters, which is a dependency of tern, rlistings, rtable. I added it on Suggests. 

There is an extra commit to update the lintr names

```r
data <- within(teal_data(), {
  ADSL <- rADSL
  ADRS <- rADRS
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

init(
  data = data,
  modules = modules(tm_missing_data())
) |> runApp()
```
