### PR TITLE
feat: use pseudo_chunk_code to remove code headers from reporter when…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,8 +84,8 @@ VignetteBuilder:
     knitr,
     rmarkdown
 Remotes:
-    insightsengineering/teal,
-    insightsengineering/teal.reporter
+    insightsengineering/teal@400-skip_headers_when_no_code,
+    insightsengineering/teal.reporter@400-skip_headers_when_no_code
 Config/Needs/verdepcheck: haleyjeppson/ggmosaic, tidyverse/ggplot2,
     rstudio/shiny, insightsengineering/teal,
     insightsengineering/teal.transform, mllg/checkmate, tidyverse/dplyr,

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -438,7 +438,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
         c(
           teal.reporter::teal_card("# Principal Component Analysis"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("tidyr")') # nolint: quotes
     })

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -463,7 +463,7 @@ srv_a_regression <- function(id,
         c(
           teal.reporter::teal_card("# Linear Regression Plot"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr")') # nolint: quotes
     })
@@ -540,8 +540,9 @@ srv_a_regression <- function(id,
         })) %>%
         teal.code::eval_code(quote({
           fit_summary <- summary(fit)
-          fit_summary
         }))
+      teal.reporter::teal_card(anl_fit) <- c(teal.reporter::teal_card(anl_fit), "## Fit summary")
+      anl_fit <- anl_fit %>% within(fit_summary)
       teal.reporter::teal_card(anl_fit) <- c(teal.reporter::teal_card(anl_fit), "## Plot")
       anl_fit
     })

--- a/R/tm_g_association.R
+++ b/R/tm_g_association.R
@@ -347,7 +347,7 @@ srv_tm_g_association <- function(id,
         c(
           teal.reporter::teal_card("# Association Plot"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
       teal.code::eval_code(obj, 'library("ggplot2");library("dplyr");library("ggmosaic")') # nolint: quotes
     })

--- a/R/tm_g_bivariate.R
+++ b/R/tm_g_bivariate.R
@@ -560,7 +560,7 @@ srv_g_bivariate <- function(id,
         c(
           teal.reporter::teal_card("# Bivariate Plot"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk(teal.reporter::pseudo_code_chunk("## Module's code")))
         )
       obj %>%
         teal.code::eval_code(

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -638,7 +638,7 @@ srv_distribution <- function(id,
         c(
           teal.reporter::teal_card("# Distribution Plot"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
 
       ANL <- obj[["ANL"]]

--- a/R/tm_g_response.R
+++ b/R/tm_g_response.R
@@ -412,7 +412,7 @@ srv_g_response <- function(id,
         c(
           teal.reporter::teal_card("# Response Plot"),
           teal.reporter::teal_card(qenv),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
       ANL <- qenv[["ANL"]]
       resp_var <- as.vector(merged$anl_input_r()$columns_source$response)

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -589,7 +589,7 @@ srv_g_scatterplot <- function(id,
       teal.reporter::teal_card(obj) <- c(
         teal.reporter::teal_card("# Scatter Plot"),
         teal.reporter::teal_card(obj),
-        teal.reporter::teal_card("## Module's code")
+        teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
       )
       teal.code::eval_code(data(), 'library("ggplot2");library("dplyr")') # nolint quotes
     })

--- a/R/tm_g_scatterplotmatrix.R
+++ b/R/tm_g_scatterplotmatrix.R
@@ -332,7 +332,7 @@ srv_g_scatterplotmatrix <- function(id,
       teal.reporter::teal_card(obj) <- c(
         teal.reporter::teal_card("# Scatter Plot Matrix"),
         teal.reporter::teal_card(obj),
-        teal.reporter::teal_card("## Module's code")
+        teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
       )
       qenv <- teal.code::eval_code(obj, 'library("dplyr");library("lattice")') # nolint quotes
       teal.code::eval_code(qenv, as.expression(anl_merged_input()$expr))

--- a/R/tm_missing_data.R
+++ b/R/tm_missing_data.R
@@ -521,7 +521,7 @@ srv_missing_data <- function(id,
       teal.reporter::teal_card(obj) <- c(
         teal.reporter::teal_card("# Missing Data"),
         teal.reporter::teal_card(obj),
-        teal.reporter::teal_card("## Module's code")
+        teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
       )
 
       qenv <- teal.code::eval_code(obj, {

--- a/R/tm_outliers.R
+++ b/R/tm_outliers.R
@@ -482,7 +482,7 @@ srv_outliers <- function(id, data, outlier_var,
         c(
           teal.reporter::teal_card("# Outliers Analysis"),
           teal.reporter::teal_card(qenv),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
 
       outlier_var <- as.vector(merged$anl_input_r()$columns_source$outlier_var)

--- a/R/tm_t_crosstable.R
+++ b/R/tm_t_crosstable.R
@@ -333,7 +333,7 @@ srv_t_crosstable <- function(id, data, label, x, y, remove_zero_columns, basic_t
         c(
           teal.reporter::teal_card("# Cross Table"),
           teal.reporter::teal_card(obj),
-          teal.reporter::teal_card("## Module's code")
+          teal.reporter::teal_card(teal.reporter::pseudo_code_chunk("## Module's code"))
         )
       teal.code::eval_code(obj, 'library("rtables");library("tern");library("dplyr")') # nolint quotes
     })


### PR DESCRIPTION
# Pull Request

- Fixes #400

### Companion to
- 

### Notes

This should be an easy find-and-replace to do the same in other modules

### Changes description

- [x] Adds `pseudo_code_chunk()` to module's code to hide that heading.
- [ ] Check if there are other headers that need hiding when code is not present