### PR TITLE
remove warning from render Table

### DIFF
--- a/R/tm_front_page.R
+++ b/R/tm_front_page.R
@@ -190,7 +190,7 @@ srv_front_page <- function(id, data, tables) {
         )
       })
 
-      output$metadata_table <- renderDataTable({
+      output$metadata_table <- DT::renderDT({
         validate(need(nrow(metadata_data_frame()) > 0, "The data has no associated metadata"))
         metadata_data_frame()
       })


### PR DESCRIPTION
This simple PR is related [to this issue](https://github.com/orgs/insightsengineering/projects/39/views/16?pane=issue&itemId=134791852&issue=insightsengineering%7Cteal.gallery%7C238)

Changes

The change is simple, just use `DT::renderDT` to remove warning.
To check please install this branch and run teal.gallery RNA seq branch.

You should not see the warning anymore.