### PR TITLE
Fix copilot-setup-steps: replace reusable workflow with direct steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,10 +1,40 @@
----
 name: Copilot Agent Setup
+
+# Configure the environment for GitHub Copilot coding agent
+# This ensures R is available when the agent works on this repository
+# Installs R using the standard GitHub Actions setup
 
 on:
   workflow_dispatch:
 
 jobs:
   copilot-setup-steps:
-    name: Copilot Agent Setup
-    uses: insightsengineering/r.pkg.template/.github/workflows/copilot-setup-steps.yaml@main
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+
+      - name: Verify R installation
+        run: |
+          R --version
+          R -e "sessionInfo()"
+      
+      # Additional steps for the Copilot agent would be invoked here
+      # The agent will have access to R in this environment


### PR DESCRIPTION
This PR fixes the GitHub Copilot setup workflow by replacing the reusable workflow call with direct steps, as required by GitHub Copilot's limitations for copilot-setup-steps jobs.

Changes:
- Removed uses: insightsengineering/r.pkg.template/.github/workflows/copilot-setup-steps.yaml@main
- Added direct steps for checkout, R setup, and dependency installation
- Uses actions with uses: (which is allowed) instead of reusable workflows (which are not)

This resolves the error: 'Calling a reusable workflow with the uses: keyword is not supported in copilot-setup-steps jobs.'