### PR TITLE
Expand linter rules for object names

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -6,7 +6,7 @@ linters: linters_with_defaults(
     regexes = c(
       ANL = "^ANL_?[0-9A-Z_]*$",
       ADaM = "^r?AD[A-Z]{2,5}_?[0-9]*$",
-      column_names = "AVAL|USUBJID|PARAM"
+      column_names = "^AVAL$|^USUBJID$|^PARAM$|^PARAMCD$"
     )
   ),
   indentation_linter = NULL,


### PR DESCRIPTION
This PR is allowing linter rules for avoiding repeating ignorint lint for object names in objects that are very common when defining ADAM related objects or using common column names.

If you add to any test file, for example in `test_front_page.R` we could add
```
testthat::test_that("convert_metadata_to_dataframe returns a data frame with metadata if more than one dataset", {
  raw_metadata <- list(list(A = "a"), list(A = "a", B = "b"))
  ADAETTE <- data.frame()
  result <- convert_metadata_to_dataframe(raw_metadata, c("ADSL", "ADAE"))
  testthat::expect_equal(
    result,
    data.frame(Dataset = c("ADSL", "ADAE", "ADAE"), Name = c("A", "A", "B"), Value = c("a", "a", "b"))
  )
})
```
And now ADAETTE if your `lintr::lint("tests/testthat/test_front_page,R")` would not trigger an error for object name (here probably it would trigger for `object_usage_linter`.
Once this PR is approved, similar one should be created for teal.modules.clinical and maybe other teal.modules package