### PR TITLE
Port changes from `teal.modules.clinical`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -381,7 +381,7 @@ assert_decorators <- checkmate::makeAssertionFunction(check_decorators)
 select_decorators <- function(decorators, scope) {
   checkmate::assert_string(scope, null.ok = FALSE)
   if (scope %in% names(decorators)) {
-    result  <- decorators[[scope]]
+    result <- decorators[[scope]]
     if (inherits(result, "teal_transform_module")) {
       result <- list(result)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -284,14 +284,19 @@ srv_decorate_teal_data <- function(id, data, decorators, expr) {
   moduleServer(id, function(input, output, session) {
     decorated_output <- srv_transform_teal_data("inner", data = data, transformators = decorators)
 
-    expr_r <- if (is.reactive(expr)) expr else reactive(expr)
-
     reactive({
-      req(decorated_output())
-      if (no_expr) {
-        decorated_output()
+      data_out <- try(data(), silent = TRUE)
+      if (inherits(data_out, "qenv.error")) {
+        data()
       } else {
-        teal.code::eval_code(decorated_output(), expr_r())
+        # ensure original errors are displayed and `eval_code` is never executed with NULL
+        req(data(), decorated_output())
+        if (no_expr) {
+          decorated_output()
+        } else {
+          expr_r <- if (is.reactive(expr)) expr else reactive(expr)
+          teal.code::eval_code(decorated_output(), expr_r())
+        }
       }
     })
   })
@@ -317,13 +322,9 @@ check_decorators <- function(x, names = NULL) { # nolint: object_name.
         "The `decorators` must contain unique names from these names: %s",
         paste(sQuote(names), collapse = ", ")
       )
-    } else if (!all(unique(names(x)) %in% c("default", names))) {
+    } else if (!all(unique(names(x)) %in% c(names))) {
       check_message <- sprintf(
-        paste0(
-          "The `decorators` must be a named list with:\n",
-          " * 'default' for decorating all objects and/or\n",
-          " * A name from these: %s"
-        ),
+        "The `decorators` must be a named list with any of the following names: %s",
         paste(sQuote(names), collapse = ", ")
       )
     }
@@ -378,8 +379,16 @@ assert_decorators <- checkmate::makeAssertionFunction(check_decorators)
 #' It can be an empty list if none of the scope exists in `decorators` argument.
 #' @keywords internal
 select_decorators <- function(decorators, scope) {
-  checkmate::assert_character(scope, null.ok = TRUE)
-  decorators[names(decorators) %in% scope]
+  checkmate::assert_string(scope, null.ok = FALSE)
+  if (scope %in% names(decorators)) {
+    result  <- decorators[[scope]]
+    if (inherits(result, "teal_transform_module")) {
+      result <- list(result)
+    }
+    result
+  } else {
+    list()
+  }
 }
 
 #' Set the attributes of the last chunk outputs

--- a/tests/testthat/test-tm_a_regression.R
+++ b/tests/testthat/test-tm_a_regression.R
@@ -156,7 +156,7 @@ describe("tests for module creation", {
     mod <- tm_a_regression(
       response = response,
       regressor = regressor,
-      decorators = list(default = ggplot_caption_decorator())
+      decorators = list(plot = ggplot_caption_decorator())
     )
 
     testthat::expect_s3_class(mod, "teal_module")

--- a/tests/testthat/test-tm_gtsummary.R
+++ b/tests/testthat/test-tm_gtsummary.R
@@ -163,7 +163,7 @@ testthat::describe("tm_gtsummary input validation", {
           plot = teal::teal_transform_module()
         )
       ),
-      "The `decorators` must be a named list with:"
+      "The `decorators` must be a named list with any of the following names:"
     )
   })
 
@@ -250,7 +250,7 @@ testthat::describe("tm_gtsummary module server behavior", {
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
         )
 
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+        testthat::expect_true(endsWith(get_code(session$returned()), "table"))
         testthat::expect_true(inherits(table_r(), "gtsummary"))
       }
     )
@@ -278,7 +278,7 @@ testthat::describe("tm_gtsummary module server behavior", {
           "include-dataset_test_data_singleextract-select" = NULL
         )
 
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+        testthat::expect_true(endsWith(get_code(session$returned()), "table"))
         testthat::expect_true(inherits(table_r(), "gtsummary"))
         testthat::expect_gt(length(unique(table_r()$table_body$variable)), 3L)
       }
@@ -308,7 +308,7 @@ testthat::describe("tm_gtsummary module server behavior", {
           "by-dataset_test_data_singleextract-select" = "am",
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
         )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+        testthat::expect_true(endsWith(get_code(session$returned()), "table"))
         table <- table_r()
         testthat::expect_equal(table$inputs$label, col_label)
         testthat::expect_true(all(table$table_body$var_label %in% unlist(col_label)))
@@ -376,9 +376,12 @@ testthat::describe("tm_gtsummary module server behavior with decorators", {
         session$setInputs(
           "by-dataset_test_data_singleextract-select" = "am",
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl"),
-          "decorate_table-transform_1-transform-caption" = cap
+          "decorate_table-inner-transform_1-transform-caption" = cap,
+          nonmissing = "no",
+          percent = "column"
         )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+
+        testthat::expect_true(endsWith(get_code(session$returned()), "table"))
         table <- table_r()
         testthat::expect_equal(as.character(table$table_styling$caption), cap)
       }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -119,7 +119,7 @@ testthat::describe("Module with decorators:", {
       by_selected = c("am"),
       include_selected = c("carb", "cyl"),
       decorators = list(
-        default = teal_transform_module()
+        table = teal_transform_module()
       )
     )
 
@@ -134,7 +134,7 @@ testthat::describe("Module with decorators:", {
           "by-dataset_test_data_singleextract-select" = "am",
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
         )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+        testthat::expect_true(endsWith(get_code(session$returned()), "table"))
       }
     )
   })
@@ -149,7 +149,7 @@ testthat::describe("Module with decorators:", {
       by_selected = c("am"),
       include_selected = c("carb", "cyl"),
       decorators = list(
-        default = teal_transform_module(server = function(id, data) {
+        table = teal_transform_module(server = function(id, data) {
           reactive({
             stop()
           })
@@ -168,7 +168,7 @@ testthat::describe("Module with decorators:", {
           "by-dataset_test_data_singleextract-select" = "am",
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
         )
-        testthat::expect_is(tryCatch(print_output_decorated(), error = function(e) e), "shiny.silent.error")
+        testthat::expect_is(tryCatch(session$returned(), error = function(e) e), "shiny.silent.error")
       }
     )
   })
@@ -186,76 +186,81 @@ testthat::describe("Module with decorators:", {
 
     shiny::testServer(
       mod$server,
-      args = c(
-        list(id = "test_data", data = data),
-        mod$server_args
-      ),
+      args = c(list(id = "test_data", data = data), mod$server_args),
       {
         session$setInputs(
           "by-dataset_test_data_singleextract-select" = "am",
           "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
         )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
+        testthat::expect_match(get_code(session$returned()), "\ntable$")
       }
     )
   })
 
-  it("Default and multiple decorators to one object execute successfully", {
-    data <- create_test_data(mtcars)
-    mod <- create_gtsummary_module(
-      data,
-      by_vars = c("am", "gear"),
-      include_vars = c("carb", "cyl"),
-      by_selected = c("am"),
-      include_selected = c("carb", "cyl"),
-      decorators = list(
-        default = teal_transform_module(),
-        table = list(teal_transform_module(), teal_transform_module())
-      )
-    )
+  # it("2 decorator objects execute successfully", {
+  #   data <- create_test_data(mtcars)
+  #   mod <- tm_g_distribution(
+  #     dist_var = data_extract_spec(
+  #       dataname = "test_data",
+  #       select = select_spec(variable_choices("test_data"), "mpg")
+  #     ),
+  #     decorators = list(
+  #       test_table = teal_transform_module(
+  #         server = function(id, data) {
+  #           reactive({
+  #             within(data(), 1 + 1)
+  #           })
+  #         }
+  #       )
+  #     )
+  #   )
 
-    shiny::testServer(
-      mod$server,
-      args = c(
-        list(id = "test_data", data = data),
-        mod$server_args
-      ),
-      {
-        session$setInputs(
-          "by-dataset_test_data_singleextract-select" = "am",
-          "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
-        )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
-      }
-    )
-  })
-  it("Default and one decorator to one object executes successfully", {
-    data <- create_test_data(mtcars)
-    mod <- create_gtsummary_module(
-      data,
-      by_vars = c("am", "gear"),
-      include_vars = c("carb", "cyl"),
-      by_selected = c("am"),
-      include_selected = c("carb", "cyl"),
-      decorators = list(
-        default = teal_transform_module(),
-        table = teal_transform_module()
-      )
-    )
+  #   shiny::testServer(
+  #     mod$server,
+  #     args = c(list(id = "test_data", data = data), mod$server_args),
+  #     {
+  #       session$setInputs(
+  #         "dist_i-dataset_test_data_singleextract-select" = "mpg",
+  #         dist_tests = "Shapiro-Wilk",
+  #         bins = 10,
+  #         main_type = "Density",
+  #         add_dens = TRUE,
+  #         tabs = "Histogram",
+  #         roundn = 2
 
-    shiny::testServer(
-      mod$server,
-      args = c(
-        list(id = "test_data", data = data),
-        mod$server_args
-      ),
-      {
-        session$setInputs(
-          "by-dataset_test_data_singleextract-select" = "am",
-          "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
-        )
-        testthat::expect_true(endsWith(get_code(print_output_decorated()), "table"))
-      }
-    )
-  })
+  #       )
+  #       testthat::expect_match(get_code(session$returned()), "\ntest_table$")
+  #     }
+  #   )
+  # })
+
+  # it("Default and one decorator to one object executes successfully", {
+  #   data <- create_test_data(mtcars)
+  #   mod <- create_gtsummary_module(
+  #     data,
+  #     by_vars = c("am", "gear"),
+  #     include_vars = c("carb", "cyl"),
+  #     by_selected = c("am"),
+  #     include_selected = c("carb", "cyl"),
+  #     decorators = list(
+  #       default = teal_transform_module(),
+  #       table = teal_transform_module()
+  #     )
+  #   )
+
+  #   shiny::testServer(
+  #     mod$server,
+  #     args = c(
+  #       list(id = "test_data", data = data),
+  #       mod$server_args
+  #     ),
+  #     {
+  #       session$setInputs(
+  #         "by-dataset_test_data_singleextract-select" = "am",
+  #         "include-dataset_test_data_singleextract-select" = c("carb", "cyl")
+  #       )
+  #       testthat::expect_true(endsWith(get_code(session$returned()), "table"))
+  #     }
+  #   )
+  # })
 })


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/teal.modules.clinical/issues/1465

### Changes description

- Unifies `srv_decorated_teal_data` implementation
- Use of `srv_decorated_teal_data` in `tm_gtsummary`
- Improvement on tests
- Removal of `default` in message about named decorators
- Fixes problem with `select_decorators()` and restricts arguments to a single scope 