### PR TITLE
Fix 'Show only distinct rows' in tm_data_table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 - Improve `tm_missing_data` visualization (#495).
 - Multiple decorators can be applied to the same output object (#978).
 
+### Bug fixes
+- `Show only distinct rows` in `tm_data_table` does no longer show an extra count column `n` (#983).
+
 # teal.modules.general 0.5.1
 
 - Removed ggmosaic package dependency to avoid being archived on CRAN (#932).

--- a/R/tm_data_table.R
+++ b/R/tm_data_table.R
@@ -320,7 +320,7 @@ srv_data_table <- function(id,
           expr = {
             variables <- vars
             dataframe_selected <- if (if_distinct) {
-              dplyr::count(dataname, dplyr::across(dplyr::all_of(variables)))
+              dplyr::distinct(dataname[variables])
             } else {
               dataname[variables]
             }

--- a/tests/testthat/test-shinytest2-tm_data_table.R
+++ b/tests/testthat/test-shinytest2-tm_data_table.R
@@ -69,9 +69,8 @@ test_that("e2e - tm_data_table: Verify module displays data table", {
   app_driver$set_active_module_input("if_distinct", TRUE)
   iris_extracted_distinct <- extract_iris_table()
   iris_subset_distinct <- iris %>%
-    dplyr::mutate(n = 1) %>%
-    dplyr::arrange(dplyr::across(dplyr::everything())) %>%
     dplyr::mutate(Species = as.character(Species)) %>%
+    dplyr::distinct() %>%
     dplyr::slice(1:30)
   testthat::expect_equal(iris_extracted_distinct, iris_subset_distinct)
 

--- a/tests/testthat/test-tm_data_table.R
+++ b/tests/testthat/test-tm_data_table.R
@@ -117,18 +117,11 @@ testthat::describe("tm_data_table module ui behavior returns a htmltools tag or 
 })
 
 
-testthat::describe("tm_g_response module server behavior", {
+testthat::describe("tm_data_table module server behavior", {
   data <- within(teal.data::teal_data(), ADSL <- teal.data::rADSL)
   variables_selected <- list(ADSL = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX"))
-  set_shared_inputs <- function(session) {
-    session$setInputs(
-      "test-variables" = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX"),
-      if_filtered = TRUE,
-      if_distinct = TRUE
-    )
-  }
 
-  it("", {
+  it("returns a teal_data object", {
     mod <- tm_data_table(variables_selected = variables_selected)
     shiny::testServer(
       mod$server,
@@ -137,9 +130,95 @@ testthat::describe("tm_g_response module server behavior", {
         list(id = "test", data = reactive(data))
       ),
       expr = {
-        set_shared_inputs(session)
+        session$setInputs(
+          "ADSL-variables" = c("STUDYID", "USUBJID", "SUBJID", "SITEID", "AGE", "SEX"),
+          if_distinct = TRUE
+        )
         session$flushReact()
         testthat::expect_s4_class(session$returned[["ADSL"]](), "teal_data")
+      }
+    )
+  })
+})
+
+testthat::describe("tm_data_table module server behavior with if_distinct option", {
+  # Create test data with explicit duplicate rows to verify distinct behavior
+  data_with_dups <- within(teal.data::teal_data(), {
+    test_df <- data.frame(
+      ID = c(1L, 2L, 2L, 3L),
+      VALUE = c("A", "B", "B", "C"),
+      stringsAsFactors = FALSE
+    )
+  })
+
+  it("returns only distinct rows when if_distinct is TRUE", {
+    mod <- tm_data_table(datanames = "test_df")
+    shiny::testServer(
+      mod$server,
+      args = c(
+        mod$server_args,
+        list(id = "test", data = reactive(data_with_dups))
+      ),
+      expr = {
+        session$setInputs(
+          if_distinct = TRUE,
+          "test_df-variables" = c("ID", "VALUE")
+        )
+        session$flushReact()
+        result <- session$returned[["test_df"]]()[["dataframe_selected"]]
+        testthat::expect_equal(nrow(result), 3L)
+      }
+    )
+  })
+
+  it("returns all rows including duplicates when if_distinct is FALSE", {
+    mod <- tm_data_table(datanames = "test_df")
+    shiny::testServer(
+      mod$server,
+      args = c(
+        mod$server_args,
+        list(id = "test", data = reactive(data_with_dups))
+      ),
+      expr = {
+        session$setInputs(
+          if_distinct = FALSE,
+          "test_df-variables" = c("ID", "VALUE")
+        )
+        session$flushReact()
+        result <- session$returned[["test_df"]]()[["dataframe_selected"]]
+        testthat::expect_equal(nrow(result), 4L)
+      }
+    )
+  })
+
+  it("does not error when variables is NULL and if_distinct is TRUE", {
+    mod <- tm_data_table(datanames = "test_df")
+    shiny::testServer(
+      mod$server,
+      args = c(
+        mod$server_args,
+        list(id = "test", data = reactive(data_with_dups))
+      ),
+      expr = {
+        session$setInputs(if_distinct = TRUE)
+        session$flushReact()
+        testthat::expect_no_error(session$returned[["test_df"]]())
+      }
+    )
+  })
+
+  it("does not error when variables is NULL and if_distinct is FALSE", {
+    mod <- tm_data_table(datanames = "test_df")
+    shiny::testServer(
+      mod$server,
+      args = c(
+        mod$server_args,
+        list(id = "test", data = reactive(data_with_dups))
+      ),
+      expr = {
+        session$setInputs(if_distinct = FALSE)
+        session$flushReact()
+        testthat::expect_no_error(session$returned[["test_df"]]())
       }
     )
   })

--- a/tests/testthat/test-tm_data_table.R
+++ b/tests/testthat/test-tm_data_table.R
@@ -191,7 +191,7 @@ testthat::describe("tm_data_table module server behavior with if_distinct option
     )
   })
 
-  it("does not error when variables is NULL and if_distinct is TRUE", {
+  it("does not error when variables is NULL regardless of if_distinct", {
     mod <- tm_data_table(datanames = "test_df")
     shiny::testServer(
       mod$server,
@@ -203,19 +203,7 @@ testthat::describe("tm_data_table module server behavior with if_distinct option
         session$setInputs(if_distinct = TRUE)
         session$flushReact()
         testthat::expect_no_error(session$returned[["test_df"]]())
-      }
-    )
-  })
 
-  it("does not error when variables is NULL and if_distinct is FALSE", {
-    mod <- tm_data_table(datanames = "test_df")
-    shiny::testServer(
-      mod$server,
-      args = c(
-        mod$server_args,
-        list(id = "test", data = reactive(data_with_dups))
-      ),
-      expr = {
         session$setInputs(if_distinct = FALSE)
         session$flushReact()
         testthat::expect_no_error(session$returned[["test_df"]]())


### PR DESCRIPTION
# Pull Request

Fixes #571 and #602

## Changes

This is a team-owned version of #983 (by @nissinbo) with review feedback incorporated.

### Fix
- Replace `dplyr::count()` with `dplyr::distinct()` to avoid adding an extra count column `n` when showing distinct rows in `tm_data_table`.
- Use `dplyr::distinct(dataname[variables])` instead of `dplyr::distinct(dataname, dplyr::across(dplyr::all_of(variables)), .keep_all = TRUE)` followed by `data_distinct[variables]`. This approach:
  - Is simpler and more readable
  - Handles the edge case where `variables` is `NULL` safely (`dataname[NULL]` is valid R, whereas `dplyr::all_of(NULL)` would error)

### Test update
- Updated the e2e test expectation to match the new distinct behavior (no extra `n` column, no re-sorting).

### NEWS
- Used the wording suggested in the review.

Co-authored-by: nissinbo <nissinbo@users.noreply.github.com>