### PR TITLE
Fix UI overlap in tm_g_distribution output panel (#896)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 - `Show only distinct rows` in `tm_data_table` does no longer show an extra count column `n` (#983).
+- Fixed overlapping UI elements in the output panel of `tm_g_distribution` (#896).
 
 # teal.modules.general 0.5.1
 

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -246,19 +246,25 @@ ui_distribution <- function(id, ...) {
         tabPanel("Histogram", teal.widgets::plot_with_settings_ui(id = ns("hist_plot"))),
         tabPanel("QQplot", teal.widgets::plot_with_settings_ui(id = ns("qq_plot")))
       ),
-      tags$h3("Statistics Table"),
-      DT::dataTableOutput(ns("summary_table")),
-      tags$h3("Tests"),
-      conditionalPanel(
-        sprintf("input['%s'].length === 0", ns("dist_tests")),
-        div(
-          id = ns("please_select_a_test"),
-          "Please select a test"
-        )
+      tags$div(
+        style = "min-height: 120px; margin-top: 1rem;",
+        tags$h3("Statistics Table"),
+        DT::dataTableOutput(ns("summary_table"))
       ),
-      conditionalPanel(
-        sprintf("input['%s'].length > 0", ns("dist_tests")),
-        DT::dataTableOutput(ns("t_stats"))
+      tags$div(
+        style = "min-height: 120px; margin-top: 1rem;",
+        tags$h3("Tests"),
+        conditionalPanel(
+          sprintf("input['%s'].length === 0", ns("dist_tests")),
+          div(
+            id = ns("please_select_a_test"),
+            "Please select a test"
+          )
+        ),
+        conditionalPanel(
+          sprintf("input['%s'].length > 0", ns("dist_tests")),
+          DT::dataTableOutput(ns("t_stats"))
+        )
       )
     ),
     encoding = tags$div(


### PR DESCRIPTION
Wrap the tabsetPanel, Statistics Table, and Tests sections of ui_distribution in separate tags$div containers with top margins, so plot_with_settings_ui validation messages and h3 section headers no longer overlap when the plot area is empty.

# Pull Request

## Summary
- Wrap the tabsetPanel, Statistics Table, and Tests sections of `ui_distribution` in separate `tags$div` containers with 1rem top margins.
- Prevents the visual overlap reported in #896 where `plot_with_settings_ui` validation messages and `h3` section headers collided when the plot area had no rendered plot.
- Closes #896.

## Test plan
-  CI green (build, R CMD check, tests)
- Reviewer visually confirms the Statistics Table / Tests headers no longer overlap the histogram tab content using the reproducer code in #896
-  Existing "shinytest2" snapshots for `tm_g_distribution` still pass (or are refreshed if DOM-sensitive)

Fixes #896