### PR TITLE
Fix #629: Replace deprecated ggplot2::aes_string() and rename sec_axis(trans=) to transform=

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Improve `tm_missing_data` visualization (#495).
 - Multiple decorators can be applied to the same output object (#978).
 - Introduced `tm_gtsummary()`, a new module for generating tables using the [gtsummary](https://cran.r-project.org/package=gtsummary) package (#973).
+- Replaced deprecated `ggplot2::aes_string()` with `aes()` using tidy evaluation idioms, and renamed `sec_axis(trans=)` to `sec_axis(transform=)` (#629).
 
 ### Bug fixes
 - `Show only distinct rows` in `tm_data_table` does no longer show an extra count column `n` (#983).

--- a/R/tm_a_pca.R
+++ b/R/tm_a_pca.R
@@ -608,7 +608,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
               )
 
             cols <- c(getOption("ggplot2.discrete.colour"), c("lightblue", "darkred", "black"))[1:3]
-            elbow_plot <- ggplot2::ggplot(mapping = ggplot2::aes_string(x = "component", y = "value")) +
+            elbow_plot <- ggplot2::ggplot(mapping = ggplot2::aes(x = component, y = value)) +
               ggplot2::geom_bar(
                 ggplot2::aes(fill = "Single variance"),
                 data = dplyr::filter(elb_dat, metric == "Proportion of Variance"),
@@ -687,9 +687,9 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
             )
 
             circle_plot <- ggplot2::ggplot(pca_rot) +
-              ggplot2::geom_point(ggplot2::aes_string(x = x_axis, y = y_axis)) +
+              ggplot2::geom_point(ggplot2::aes(x = .data[[x_axis]], y = .data[[y_axis]])) +
               ggplot2::geom_label(
-                ggplot2::aes_string(x = x_axis, y = y_axis, label = "label"),
+                ggplot2::aes(x = .data[[x_axis]], y = .data[[y_axis]], label = label),
                 nudge_x = 0.1, nudge_y = 0.05,
                 fontface = "bold"
               ) +
@@ -789,7 +789,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
         pca_plot_biplot_expr <- c(
           pca_plot_biplot_expr,
           substitute(
-            ggplot2::geom_point(ggplot2::aes_string(x = x_axis, y = y_axis),
+            ggplot2::geom_point(ggplot2::aes(x = .data[[x_axis]], y = .data[[y_axis]]),
               data = pca_rot, alpha = alpha, size = size
             ),
             list(x_axis = input$x_axis, y_axis = input$y_axis, alpha = input$alpha, size = input$size)
@@ -802,7 +802,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
         response <- ANL[[resp_col]]
 
         aes_biplot <- substitute(
-          ggplot2::aes_string(x = x_axis, y = y_axis, color = "response"),
+          ggplot2::aes(x = .data[[x_axis]], y = .data[[y_axis]], color = response),
           env = list(x_axis = x_axis, y_axis = y_axis)
         )
 
@@ -860,7 +860,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
           pca_plot_biplot_expr,
           substitute(
             ggplot2::geom_segment(
-              ggplot2::aes_string(x = "xstart", y = "ystart", xend = x_axis, yend = y_axis),
+              ggplot2::aes(x = xstart, y = ystart, xend = .data[[x_axis]], yend = .data[[y_axis]]),
               data = rot_vars,
               lineend = "round", linejoin = "round",
               arrow = grid::arrow(length = grid::unit(0.5, "cm"))
@@ -869,10 +869,10 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
           ),
           substitute(
             ggplot2::geom_label(
-              ggplot2::aes_string(
-                x = x_axis,
-                y = y_axis,
-                label = "label"
+              ggplot2::aes(
+                x = .data[[x_axis]],
+                y = .data[[y_axis]],
+                label = label
               ),
               data = rot_vars,
               nudge_y = 0.1,
@@ -965,7 +965,7 @@ srv_a_pca <- function(id, data, dat, plot_height, plot_width, ggplot2_args, deco
           quote(ggplot(pca_rot)),
           substitute(
             ggplot2::geom_bar(
-              ggplot2::aes_string(x = "Variable", y = pc),
+              ggplot2::aes(x = Variable, y = .data[[pc]]),
               stat = "identity",
               color = "black",
               fill = c(getOption("ggplot2.discrete.colour"), "lightblue")[1]

--- a/R/tm_a_regression.R
+++ b/R/tm_a_regression.R
@@ -589,7 +589,7 @@ srv_a_regression <- function(id,
             as.data.frame(stats::lowess(x, y, f = 2 / 3, iter = 3))
           }
 
-          smoothy_aes <- ggplot2::aes_string(x = "x", y = "y")
+          smoothy_aes <- ggplot2::aes(x = x, y = y)
 
           reg_form <- deparse(fit$call[[2]])
         })
@@ -606,7 +606,7 @@ srv_a_regression <- function(id,
         shinyjs::show("size")
         shinyjs::show("alpha")
         plot <- substitute(
-          expr = ggplot2::ggplot(fit$model[, 2:1], ggplot2::aes_string(regressor, response)) +
+          expr = ggplot2::ggplot(fit$model[, 2:1], ggplot2::aes(x = .data[[regressor]], y = .data[[response]])) +
             ggplot2::geom_point(size = size, alpha = alpha) +
             ggplot2::stat_smooth(method = "lm", formula = y ~ x, se = FALSE),
           env = list(
@@ -626,7 +626,7 @@ srv_a_regression <- function(id,
         shinyjs::hide("size")
         shinyjs::hide("alpha")
         plot <- substitute(
-          expr = ggplot2::ggplot(fit$model[, 2:1], ggplot2::aes_string(regressor, response)) +
+          expr = ggplot2::ggplot(fit$model[, 2:1], ggplot2::aes(x = .data[[regressor]], y = .data[[response]])) +
             ggplot2::geom_boxplot(),
           env = list(regressor = regression_var()$regressor, response = regression_var()$response)
         )

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -996,17 +996,17 @@ srv_distribution <- function(id,
 
         plot_call <- if (length(s_var) == 0 && length(g_var) == 0) {
           substitute(
-            expr = ggplot2::ggplot(ANL, ggplot2::aes_string(sample = dist_var)),
+            expr = ggplot2::ggplot(ANL, ggplot2::aes(sample = .data[[dist_var]])),
             env = list(dist_var = dist_var)
           )
         } else if (length(s_var) != 0 && length(g_var) == 0) {
           substitute(
-            expr = ggplot2::ggplot(ANL, ggplot2::aes_string(sample = dist_var, color = s_var)),
+            expr = ggplot2::ggplot(ANL, ggplot2::aes(sample = .data[[dist_var]], color = .data[[s_var]])),
             env = list(dist_var = dist_var, s_var = s_var)
           )
         } else if (length(s_var) == 0 && length(g_var) != 0) {
           substitute(
-            expr = ggplot2::ggplot(ANL[ANL[[g_var]] != "NA", ], ggplot2::aes_string(sample = dist_var)) +
+            expr = ggplot2::ggplot(ANL[ANL[[g_var]] != "NA", ], ggplot2::aes(sample = .data[[dist_var]])) +
               ggplot2::facet_wrap(~g_var_name, ncol = 1, scales = scales_raw),
             env = list(
               dist_var = dist_var,
@@ -1017,7 +1017,7 @@ srv_distribution <- function(id,
           )
         } else {
           substitute(
-            expr = ggplot2::ggplot(ANL[ANL[[g_var]] != "NA", ], ggplot2::aes_string(sample = dist_var, color = s_var)) +
+            expr = ggplot2::ggplot(ANL[ANL[[g_var]] != "NA", ], ggplot2::aes(sample = .data[[dist_var]], color = .data[[s_var]])) +
               ggplot2::facet_wrap(~g_var_name, ncol = 1, scales = scales_raw),
             env = list(
               dist_var = dist_var,

--- a/R/tm_g_distribution.R
+++ b/R/tm_g_distribution.R
@@ -1017,7 +1017,10 @@ srv_distribution <- function(id,
           )
         } else {
           substitute(
-            expr = ggplot2::ggplot(ANL[ANL[[g_var]] != "NA", ], ggplot2::aes(sample = .data[[dist_var]], color = .data[[s_var]])) +
+            expr = ggplot2::ggplot(
+              ANL[ANL[[g_var]] != "NA", ],
+              ggplot2::aes(sample = .data[[dist_var]], color = .data[[s_var]])
+            ) +
               ggplot2::facet_wrap(~g_var_name, ncol = 1, scales = scales_raw),
             env = list(
               dist_var = dist_var,

--- a/R/tm_variable_browser.R
+++ b/R/tm_variable_browser.R
@@ -754,7 +754,7 @@ plot_var_summary <- function(qenv,
             ggplot2::geom_histogram(binwidth = binwidth) +
             ggplot2::scale_y_continuous(
               sec.axis = ggplot2::sec_axis(
-                trans = ~ . / nrow(ANL),
+                transform = ~ . / nrow(ANL),
                 labels = scales::percent,
                 name = "proportion (in %)"
               )


### PR DESCRIPTION
Fix #629

## Changes

Replaces deprecated `ggplot2` functions and arguments per the issue's acceptance criteria:

- **`ggplot2::aes_string()` → `ggplot2::aes()`** using tidy evaluation idioms:
  - `.data[[var]]` for string-valued R variables (e.g. from `input$x_axis`)
  - Bare names for hardcoded literal column names
- **`ggplot2::sec_axis(trans=)` → `ggplot2::sec_axis(transform=)`** — argument renamed in ggplot2 3.5.0

## Files modified

- `R/tm_a_pca.R` — 8 `aes_string` occurrences replaced
- `R/tm_a_regression.R` — 3 `aes_string` occurrences replaced
- `R/tm_g_distribution.R` — 4 `aes_string` occurrences replaced
- `R/tm_variable_browser.R` — `sec_axis(trans=)` renamed to `sec_axis(transform=)`

**Total:** 16 changes across 4 files, split into 4 commits (one per file) for easier review.

## Design note

For `aes_string()` calls inside `substitute()` blocks (used for teal's reproducible 
code generation via `teal.code`), the captured expressions now use `.data[[var]]`. 
This means the "Show R Code" output will display patterns like 
`aes(x = .data[["Sepal.Length"]], y = .data[["Petal.Length"]])` instead of the 
old `aes_string(x = "Sepal.Length", y = "Petal.Length")`.

An alternative approach would be to splice column names as symbols via `as.name()`, 
which would produce cleaner `aes(x = Sepal.Length)` output. Happy to switch to that 
approach if preferred — let me know.

## Testing

Module-specific tests all pass locally:

- `devtools::test(filter = "tm_a_pca")` → 52 PASS, 0 FAIL, 0 WARN
- `devtools::test(filter = "tm_a_regression")` → 41 PASS, 0 FAIL, 0 WARN
- `devtools::test(filter = "tm_g_distribution")` → 35 PASS, 0 FAIL, 0 WARN
- `devtools::test(filter = "tm_variable_browser")` → 144 PASS, 0 FAIL, 0 WARN

Full suite: 917 PASS, 1 FAIL, 0 WARN. The single failure (`test-tm_front_page.R:52` — 
`show_metadata is deprecated`) is pre-existing on `main` and unrelated to this PR; it's 
caused by ANSI color codes in the `lifecycle` deprecation message breaking a regex match 
in the test.

## Hackathon

R/Medicine 2026 Pharmaverse Hackathon — Track A.

Please label this PR with `TrackA_RMedicine_Hackathon_Apr2026`.