### PR TITLE
Fix tm_outliers joins for compound keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.modules.general 0.8.0.9000
 
+### Bug fixes
+
+- `tm_outliers()` now preserves compound primary keys when analyzing a child dataset with `picks()` (#1011).
+
 # teal.modules.general 0.8.0
 
 ### Enhancements

--- a/R/tm_outliers_picks.R
+++ b/R/tm_outliers_picks.R
@@ -268,6 +268,17 @@ srv_outliers.picks <- function(id, # nolint: object_name_linter.
     # dataset holding the outlier variable, used to fetch additional columns
     outlier_dataname <- reactive(selectors$outlier_var()$datasets$selected)
 
+    # Keep the full primary key so outlier rows can be joined back to the source
+    # dataset without falling back to a non-unique foreign key.
+    outlier_join_keys <- reactive({
+      dataname <- outlier_dataname()
+      primary_keys <- as.character(teal.data::join_keys(data_obj())[dataname, dataname])
+      teal.picks::picks(
+        teal.picks::datasets(dataname, dataname),
+        teal.picks::variables(primary_keys, primary_keys, multiple = TRUE)
+      )
+    })
+
     validated_q <- reactive({
       obj <- req(data_obj())
       outlier_dat <- obj[[outlier_dataname()]]
@@ -307,7 +318,12 @@ srv_outliers.picks <- function(id, # nolint: object_name_linter.
       teal.code::eval_code(obj, "library(dplyr);library(tidyr);library(tibble);library(ggplot2)")
     })
 
-    merged <- teal.picks::merge_srv("merge", data = validated_q, selectors = selectors, output_name = "ANL")
+    merged <- teal.picks::merge_srv(
+      "merge",
+      data = validated_q,
+      selectors = c(selectors, list(outlier_join_keys = outlier_join_keys)),
+      output_name = "ANL"
+    )
 
     n_outlier_missing <- reactive({
       req(merged$data())

--- a/tests/testthat/test-tm_outliers_picks.R
+++ b/tests/testthat/test-tm_outliers_picks.R
@@ -1,0 +1,40 @@
+testthat::test_that("tm_outliers keeps compound keys for child datasets", {
+  data <- teal.data::teal_data()
+  data <- within(data, {
+    ADSL <- teal.data::rADSL
+    ADLB <- teal.data::rADLB
+  })
+  teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[c("ADSL", "ADLB")]
+
+  mod <- tm_outliers(
+    outlier_var = teal.picks::picks(
+      teal.picks::datasets("ADLB", "ADLB"),
+      teal.picks::variables("AVAL", "AVAL", multiple = FALSE)
+    ),
+    categorical_var = teal.picks::picks(
+      teal.picks::datasets("ADLB", "ADLB"),
+      teal.picks::variables(c("PARAMCD", "AVISIT"), selected = NULL, multiple = FALSE)
+    )
+  )
+
+  shiny::testServer(
+    mod$server,
+    args = c(list(id = "test", data = shiny::reactive(data)), mod$server_args),
+    expr = {
+      .change_selectors(selectors, outlier_var = "AVAL", categorical_var = NULL)
+      session$setInputs(
+        method = "IQR",
+        iqr_slider = 1.5,
+        split_outliers = FALSE,
+        order_by_outlier = FALSE
+      )
+
+      result <- common_code_q()
+      outliers <- result[["ANL_OUTLIER"]]
+      extended <- result[["ANL_OUTLIER_EXTENDED"]]
+
+      testthat::expect_true(all(c("STUDYID", "USUBJID", "PARAMCD", "AVISIT") %in% names(outliers)))
+      testthat::expect_equal(nrow(extended), nrow(outliers))
+    }
+  )
+})


### PR DESCRIPTION
## Summary

Preserve complete primary keys in the `picks()` implementation of `tm_outliers()` so child datasets with compound keys can populate the outlier table.

## Thanks to maintainers

Thanks for maintaining the module and for taking the time to review this focused fix.

## Issue or motivation

Fixes #1011. With ADLB selected and no categorical variable, the merged analysis kept only `STUDYID` and `USUBJID`, while the outlier table joined back on `STUDYID`, `USUBJID`, `PARAMCD`, and `AVISIT`.

## Root cause

`teal.picks::merge_srv()` retains the child dataset's foreign key unless other variables are selected. `srv_outliers.picks()` later needs the complete primary key to retrieve additional columns, so the generated join referenced columns absent from `ANL`.

## Change

Add an internal selector for the selected outlier dataset's primary key before merging. The regression test uses `rADSL` and `rADLB`, leaves the categorical selection empty, and checks both complete-key retention and stable row counts.

## Tests

- `TESTING_DEPTH=4 NOT_CRAN=true R CMD check --as-cran --no-manual`: no errors or warnings; one expected development-version NOTE.
- `TESTING_DEPTH=5` browser tests: `tm_outliers` passed 61 assertions. The full run's two `tm_file_viewer` failures were reproduced unchanged on a clean `origin/main` worktree.
- Focused and related `tm_outliers` tests passed (84 assertions).
- `lintr` passed on the changed R files; `styler` reported no changes.

## Scope

This only changes the `picks()` merge inputs and adds regression coverage. It does not change the legacy `data_extract_spec` path, public arguments, plots, or `teal.picks` merge behavior.
